### PR TITLE
Add drop-down for Vision navbar/top nav item

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,19 +121,19 @@ const config = {
             position: 'right',
             items: [
               {
-                to: 'docs/client-sdk/javascript/concepts/intro-to-sdk',
+                to: 'about/roadmap',
                 html: `<div class="navbar__client__dropdown"><div class="navbar__client__dropdown__icon"><img src="/img/client-icon.svg" alt="icon" /></div>
                  <div class="navbar__client__dropdown_text"><div>Roadmap</div>
                  <div><small>Learn about what's in store for XMTP in the months ahead</small></div></div></div>`,
               },
               {
-                to: 'docs/client-sdk/javascript/concepts/intro-to-sdk',
+                to: 'about/litepaper',
                 html: `<div class="navbar__client__dropdown"><div class="navbar__client__dropdown__icon"><img src="/img/client-icon.svg" alt="icon" /></div>
                  <div class="navbar__client__dropdown_text"><div>Litepaper</div>
                  <div><small>Read the public draft of the XMTP Litepaper</small></div></div></div>`,
               },
               {
-                to: 'docs/client-sdk/javascript/concepts/intro-to-sdk',
+                to: 'about/case-study-token-gate-chat',
                 html: `<div class="navbar__client__dropdown"><div class="navbar__client__dropdown__icon"><img src="/img/client-icon.svg" alt="icon" /></div>
                  <div class="navbar__client__dropdown_text"><div>Case study: Token-gated chat</div>
                  <div><small>@NftTopBest demonstrates one future for trustless messaging</small></div></div></div>`,


### PR DESCRIPTION
- Addresses https://github.com/xmtp/xmtp-dot-org/issues/87
- Open question: Do we want to provide an icon for each entry in the drop-down? (FYI that the case study is a placeholder for @petermdenton - I don't know what the actual topic of the case study will be for launch). As this Vision area grows, we'll probably be unable to provide a meaningful icon for every page. Should we just remove them? Or do we want to keep them and remove them if the pattern becomes unsustainable?