### PR TITLE
Add access to the newly released public repo for the XMTP Quickstart React App

### DIFF
--- a/community/community.md
+++ b/community/community.md
@@ -30,7 +30,8 @@ Keep up with the latest news and insights from XMTP.
 Contribute to XMTP open source projects to help improve the SDKs, developer tools, protocol, and documentation.
 
 * [View XMTP JavaScript SDK open issues](https://github.com/xmtp/xmtp-js/issues)
-* [View example chat app open issues](https://github.com/xmtp/example-chat-react/issues)
+* [View XMTP Chat app open issues](https://github.com/xmtp/example-chat-react/issues)
+* [View XMTP Quickstart React App open issues](https://github.com/xmtp/xmtp-quickstart-react/issues)
 * [Contribute to XMTP documentation](https://github.com/xmtp/xmtp-dot-org#readme)
 
 ### 🐞 Bugs

--- a/docs/dev-concepts/faq.md
+++ b/docs/dev-concepts/faq.md
@@ -153,12 +153,11 @@ XMTP enables developers to implement messaging features and UX paradigms that be
 
 ### Does XMTP support real-time conversations?
 
-Real-time chat is a core use case for XMTP and is demonstrated by the XMTP example chat app.
+Real-time chat is a core use case for XMTP and is demonstrated by the XMTP Chat app.
 
-- [Try the app](https://xmtp.chat/) connected to the XMTP `production` network
-- [Try the app](https://xmtp.vercel.app/) connected to the XMTP `dev` network
+[Try the app](https://xmtp.chat/) connected to the XMTP `production` network
 
-To learn more about how the XMTP example chat app is built, see the [example-chat-react repo](https://github.com/xmtp/example-chat-react).
+To learn more about how the XMTP Chat app is built, see the [example-chat-react repo](https://github.com/xmtp/example-chat-react).
 
 ### Does XMTP support group messaging?
 

--- a/docs/dev-concepts/signatures.md
+++ b/docs/dev-concepts/signatures.md
@@ -20,7 +20,7 @@ Let’s dive deeper into the details of what happens behind the scenes when you 
 
 The first time you use an app built with XMTP to send or receive messages, you’re prompted to sign to create a public identity on the XMTP network.
 
-For example, here’s the MetaMask **Signature Request** window that displays when connecting to XMTP’s example chat app:
+For example, here’s the MetaMask **Signature Request** window that displays when connecting to the XMTP Chat app:
 
 ![MetaMask wallet browser extension Signature Request window showing an "XMTP: Create Identity" message](img/create-identity.png)
 
@@ -46,7 +46,7 @@ Once you’ve successfully signed to create an XMTP identity, you’ll never be 
 
 After you’ve signed to create an XMTP identity (first-time only) and anytime you start a new messaging session using an app built with XMTP, you’re prompted to sign to enable your XMTP identity.
 
-For example, here’s the Coinbase Wallet **Signature requested** window that displays when connecting to XMTP’s example chat app:
+For example, here’s the Coinbase Wallet **Signature requested** window that displays when connecting to the XMTP Chat app:
 
 ![Coinbase browser extension Signature requested window showing an "XMTP: Enable Identity" message](img/enable-identity.png)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -244,11 +244,15 @@ const config = {
                 href: 'https://github.com/xmtp/xmtp-js',
               },
               {
-                label: 'Example chat app repo',
+                label: 'XMTP Quickstart React App repo',
+                href: 'https://github.com/xmtp/xmtp-quickstart-react',
+              },
+              {
+                label: 'XMTP Chat app repo',
                 href: 'https://github.com/xmtp/example-chat-react/',
               },
               {
-                label: 'Hosted example chat app',
+                label: 'Hosted XMTP Chat app',
                 href: 'https://xmtp.chat/',
               },
             ],

--- a/src/components/MainContent/index.js
+++ b/src/components/MainContent/index.js
@@ -10,6 +10,7 @@ import {
   HEADER_DATA,
   BLOG_DATA,
   XMTP_JS_URL,
+  QUICKSTART_CHAT_URL,
   EXAMPLE_CHAT_URL,
   CHAT_ITEM,
 } from '../../helpers/constants'
@@ -31,6 +32,11 @@ export const MainContent = ({ styles }) => {
         Authorization: customFields.personalToken,
       },
     })
+    const responseQuickChat = await fetch(QUICKSTART_CHAT_URL, {
+      headers: {
+        Authorization: customFields.personalToken,
+      },
+    })
     const responseChat = await fetch(EXAMPLE_CHAT_URL, {
       headers: {
         Authorization: customFields.personalToken,
@@ -39,6 +45,8 @@ export const MainContent = ({ styles }) => {
 
     const dataXmtp = await responseXmtp.json()
     if (dataXmtp && !dataXmtp.message) items = [...items, dataXmtp]
+    const dataQuickChat = await responseQuickChat.json()
+    if (dataQuickChat && !dataQuickChat.message) items = [...items, dataQuickChat]
     const dataChat = await responseChat.json()
     if (dataChat && !dataChat.message) items = [...items, dataChat]
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -84,12 +84,12 @@ export const BLOG_DATA = [
 ]
 
 export const XMTP_JS_URL = 'https://api.github.com/repos/xmtp/xmtp-js'
-export const EXAMPLE_CHAT_URL =
-  'https://api.github.com/repos/xmtp/example-chat-react'
+export const QUICKSTART_CHAT_URL = 'https://api.github.com/repos/xmtp/xmtp-quickstart-react'
+export const EXAMPLE_CHAT_URL = 'https://api.github.com/repos/xmtp/example-chat-react'
 
 export const CHAT_ITEM = {
   id: '2534740',
-  full_name: 'Hosted example app',
+  full_name: 'Hosted XMTP Chat app',
   description:
     'Hosted example-react-app connected to the XMTP production network',
   text: 'Try it',

--- a/src/pages/sdks-and-tools.mdx
+++ b/src/pages/sdks-and-tools.mdx
@@ -5,21 +5,27 @@ import Feedback from '/src/components/Feedback'
 
 # XMTP SDK and developer tools
 
-## Client SDK
+## XMTP client SDK for Javascript
 
-The XMTP JavaScript SDK is a TypeScript implementation of an XMTP client for use with JavaScript and React apps.
+A TypeScript implementation of an XMTP client for use with JavaScript and React apps.
 
 [GitHub repo](https://github.com/xmtp/xmtp-js) | [Docs](docs/client-sdk/javascript/tutorials/quickstart)
 
-## Example XMTP client app repo
+## XMTP Quickstart React App repo
 
-`example-chat-react` is an example React chat app that demonstrates the core features of the `xmtp-js` client implementation.
+An example React chat app you can use as a developer tool to learn how to build a basic messaging app using the XMTP client SDK. The app is intentionally streamlined and unopinionated, which can make it a good launching point for building with XMTP.
+
+[GitHub repo](https://github.com/xmtp/xmtp-quickstart-react)
+
+## XMTP Chat app repo
+
+An example React chat app that demonstrates both basic and advanced features of the XMTP client SDK.
 
 [GitHub repo](https://github.com/xmtp/example-chat-react)
 
-## Hosted example client app
+## Hosted XMTP Chat app
 
-XMTP Labs hosts a deployment of the `example-chat-react` app connected to the `production` network.
+XMTP Labs hosts a deployment of XMTP Chat connected to the XMTP `production` network.
 
 [Try it](https://xmtp.chat)
 


### PR DESCRIPTION
Surfaces access to the XMTP Quickstart React App repo in the following locations:
- SDK and tools page
- SDK and tools module on home page
- Updates references to "XMTP example app" to reflect new naming: XMTP Chat app