### PR TITLE
Add link to XMTP status page to "SDK and tools" page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -255,6 +255,10 @@ const config = {
                 label: 'Hosted XMTP Chat app',
                 href: 'https://xmtp.chat/',
               },
+              {
+                label: 'XMTP status page',
+                href: 'https://status.xmtp.com/',
+              },
             ],
           },
           {

--- a/src/pages/sdks-and-tools.mdx
+++ b/src/pages/sdks-and-tools.mdx
@@ -29,4 +29,10 @@ XMTP Labs hosts a deployment of XMTP Chat connected to the XMTP `production` net
 
 [Try it](https://xmtp.chat)
 
+## XMTP status
+
+View the real-time status of the XMTP production network, XMTP dev network, and XMTP Chat app.
+
+[View status page](https://status.xmtp.com/)
+
 <Feedback url="https://github.com/orgs/xmtp/discussions/categories/q-a"/>


### PR DESCRIPTION
- Surfacing the link on the SDK and tools page.
- If we find that people need more obvious access, we can surface the link in the top nav. Trying to keep that area lean for now.