### PR TITLE
Reorg architectural overview

### DIFF
--- a/docs/dev-concepts/algorithms-in-use.mdx
+++ b/docs/dev-concepts/algorithms-in-use.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Algorithms in use
-sidebar_position: 7
+sidebar_position: 11
 ---
 import Feedback from '/src/components/Feedback'
 

--- a/docs/dev-concepts/app-layer.md
+++ b/docs/dev-concepts/app-layer.md
@@ -1,0 +1,37 @@
+---
+sidebar_label: App layer
+sidebar_position: 5
+---
+
+# App layer of XMTP
+
+At the most basic level, the architecture of XMTP (Extensible Message Transport Protocol) includes three layers:
+
+* Network layer
+* Client layer
+* App layer
+
+![Diagram showing three layers of the XMTP architecture: network, client, and app.](img/arch-layers.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=0%3A1](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=0%3A1)-->
+
+This topic provides an overview of the app layer of XMTP.
+
+The app layer consists of client apps built with the XMTP client SDK.
+
+A developer can provide messaging between blockchain accounts in their app by building with the [XMTP client SDK](https://github.com/xmtp/xmtp-js). When a developer builds with the SDK, their app embeds an XMTP message API client, which communicates with a message API in an XMTP node to handle all XMTP network interactions required to enable their users to send and receive messages. To learn more, see [XMTP node diagram](network-layer#xmtp-node-diagram).
+
+With XMTP network interactions handled by the message API client, developers can focus on the user-related aspects of building client apps, such as:
+
+* User acquisition
+* User interface
+* User identity metadata
+* Inbox filtering  
+To learn about one developer's approach, see [Truths Not Spoofs](https://blog.xmtp.com/truths-not-spoofs/).
+* Custom content types  
+To learn more, see [Content types](content-types).
+
+Developers can also help shape XMTP by participating in [XMTP Improvement Proposals (XIPs)](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) and [contributing](contributing) to XMTP SDKs and tools.
+
+## Learn more
+
+* [Network layer](network-layer)
+* [Client layer](client-layer)

--- a/docs/dev-concepts/app-layer.md
+++ b/docs/dev-concepts/app-layer.md
@@ -17,7 +17,7 @@ This topic provides an overview of the app layer of XMTP.
 
 The app layer consists of client apps built with the XMTP client SDK.
 
-A developer can provide messaging between blockchain accounts in their app by building with the [XMTP client SDK](https://github.com/xmtp/xmtp-js). When a developer builds with the SDK, their app embeds an XMTP message API client, which communicates with a message API in an XMTP node to handle all XMTP network interactions required to enable their users to send and receive messages. To learn more, see [XMTP node diagram](network-layer#xmtp-node-diagram).
+A developer can provide messaging between blockchain accounts in their app by building with the [XMTP client SDK](https://github.com/xmtp/xmtp-js). When a developer builds with the SDK, their app embeds an XMTP message API client, which communicates with a message API in an XMTP node to handle all XMTP network interactions required to enable their users to send and receive messages. To learn more, see [Network layer](network-layer).
 
 With XMTP network interactions handled by the message API client, developers can focus on the user-related aspects of building client apps, such as:
 

--- a/docs/dev-concepts/architectural-overview.md
+++ b/docs/dev-concepts/architectural-overview.md
@@ -26,7 +26,7 @@ The network layer provides the XMTP network which is comprised of **nodes** (com
 
 The XMTP network enables any computer running XMTP node software to participate in the network. Currently, the node software is closed source and all nodes in the XMTP network are operated by XMTP Labs. XMTP Labs is working toward a phased decentralization of the network and will share a roadmap in the coming months.
 
-This diagram shows the key components of an XMTP node. The nodes provide a **message API** that enables client apps built with the XMTP client SDK to communicate with the XMTP network. The nodes use Waku node software to connect to other nodes and form a peer-to-peer network to relay and store envelopes submitted and requested by client apps.
+This diagram shows the key components of an XMTP node. The nodes provide a **message API** that enables client apps built with the XMTP client SDK to communicate with the XMTP network. The nodes use Waku node software to connect to other nodes and form a peer-to-peer network to relay and store envelopes submitted and requested by client apps. Currently, nodes are configured to rate limit high-volume publishing from message API clients.
 
 <a name="xmtp-node-diagram"></a>
 

--- a/docs/dev-concepts/client-layer.md
+++ b/docs/dev-concepts/client-layer.md
@@ -1,57 +1,19 @@
 ---
-sidebar_label: Architectural overview
-sidebar_position: 2
-toc_max_heading_level: 4
+sidebar_label: Client layer
+sidebar_position: 4
 ---
-import Feedback from '/src/components/Feedback'
 
-# Architectural overview of XMTP
+# Client layer of XMTP
 
-This topic provides an introduction to the architecture of XMTP (Extensible Message Transport Protocol) and how it supports messaging between blockchain accounts.
+At the most basic level, the architecture of XMTP (Extensible Message Transport Protocol) includes three layers:
 
-You can use this information to get an overview of how XMTP works and how building with XMTP can fit into your architecture and environment.
-
-At the most basic level, the architecture of XMTP includes three layers:
-
-* [Network layer](#network-layer)
-* [Client layer](#client-layer)
-* [App layer](#app-layer)
+* Network layer
+* Client layer
+* App layer
 
 ![Diagram showing three layers of the XMTP architecture: network, client, and app.](img/arch-layers.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=0%3A1](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=0%3A1)-->
 
-
-## Network layer
-
-The network layer provides the XMTP network which is comprised of **nodes** (computers) running XMTP node software.
-
-The XMTP network enables any computer running XMTP node software to participate in the network. Currently, the node software is closed source and all nodes in the XMTP network are operated by XMTP Labs. XMTP Labs is working toward a phased decentralization of the network and will share a roadmap in the coming months.
-
-This diagram shows the key components of an XMTP node. The nodes provide a **message API** that enables client apps built with the XMTP client SDK to communicate with the XMTP network. The nodes use Waku node software to connect to other nodes and form a peer-to-peer network to relay and store envelopes submitted and requested by client apps. Currently, nodes are configured to rate limit high-volume publishing from message API clients.
-
-<a name="xmtp-node-diagram"></a>
-
-![Diagram showing three nodes connected in a peer-to-peer fashion to form the XMTP network. The diagram shows the key components of a node, including a message API and Waku node. The diagram also shows a client app connecting a message API client to the message API in a node.](img/xmtp-nodes.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=16%3A502](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=16%3A502)-->
-
-Every **envelope** contains a payload, often encrypted, that is not observable by nodes. The payload could be a public key bundle, private key bundle, or a message created by a client app, but this information is opaque to nodes. Meaning is assigned to these envelopes in the [Client layer](#client-layer).
-
-Nodes can see envelope properties which help the nodes understand how to handle envelopes but the properties reveal nothing about message content. An example of an important envelope property is a **topic** name. A topic name is a required envelope property. A topic name helps a node understand where to relay and store the envelope. Each envelope belongs to exactly one topic.
-
-The primary responsibilities of an XMTP node are to:
-
-* Connect to other nodes, forming a peer-to-peer network
-* Advertise information about all of the nodes it’s connected to, enabling newly joined nodes to connect to other nodes in the XMTP network
-* Relay envelopes to other nodes
-* Store envelopes in topics
-* Make envelopes available for retrieval by client apps
-
-<!--To learn more about the XMTP network layer, nodes, and topics, see Network Layer in The XMTP Protocol specifications.-->
-
-Here’s a high-level view of how XMTP nodes relay and store envelopes containing payloads submitted and retrieved by client apps built with XMTP:
-
-![Animation showing the flow of a user sending a message to another user, including how the sender's client app encrypts and submits the message to the XMTP network, how an XMTP node relays the message to other nodes, and how the recipient's client app retrieves the message from the network, decrypts it, and delivers it to the recipient.](img/xmtp-message-flow.gif)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=1%3A169](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=1%3A169)--><!--change paper icons to open vs closed envelopes-->
-
-
-## Client layer
+This topic provides an overview of the client layer of XMTP.
 
 The client layer consists of XMTP message API clients (clients) embedded in client apps built with the XMTP client SDK. A message API client connects to the message API in an arbitrary XMTP node to communicate with the network, as shown in the [XMTP node diagram](#xmtp-node-diagram).
 
@@ -69,7 +31,7 @@ To learn more, see [Invitation and message encryption](invitation-and-message-en
 To learn more, see [Content types](content-types).
 
 
-### XMTP V2 topics and message presentation flow
+## XMTP V2 topics and message presentation flow
 
 This section describes how topics and the message presentation flow work for the current version of the protocol, referred to as XMTP V2. Only client apps with XMTP client SDK >=v7.0.0 can use XMTP V2. To learn about how topics and flows work in XMTP V1, see [XMTP V1 topics and message presentation flow](#xmtp-v1-topics-and-message-presentation-flow).
 
@@ -144,7 +106,7 @@ In this flow, the client app:
 <!--To learn more about keys, contacts, invitations, and messages, see Client Layer in The XMTP Protocol specifications.-->
 
 
-### XMTP V1 topics and message presentation flow
+## XMTP V1 topics and message presentation flow
 
 This section describes how topics and the message presentation flow work for XMTP V1. To understand whether a client app will use XMTP V1 or V2, see [Determining whether to use XMTP V2 or V1 topics](#determining-whether-to-use-xmtp-v2-or-v1-topics).
 
@@ -214,30 +176,15 @@ In this flow, the client app:
 For more details, see [Invitation and message encryption](invitation-and-message-encryption).
 
 
-### Determining whether to use XMTP V2 or V1 topics
+## Determining whether to use XMTP V2 or V1 topics
 
 The following diagram shows how a client app using XMTP client SDK >=v7.0.0 determines whether it can use [XMTP V2 topics and message presentation flow](#xmtp-v2-topics-and-message-presentation-flow) or if it must use [XMTP V1 topics and message presentation flow](#xmtp-v1-topics-and-message-presentation-flow) to communicate with another client app.
 
 ![Diagram showing a decision tree of how a client app using SDK >=v7.0.0 determines whether it can use XMTP V2 or V1 topics to communicate with another client app](img/v1-or-v2-decision-tree.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=1%3A1657](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=1%3A1657)-->
 
 A contact topic may contain multiple versions of a public key bundle for a user. For example, `PublicKeyBundleV2` and `PublicKeyBundleV1`.
-<!--should I hide these for now? Not live yet, correct?-->
 
+## Learn more
 
-## App layer
-
-The app layer consists of client apps built with the XMTP client SDK.
-
-A developer can provide messaging between blockchain accounts in their app by building with the [XMTP client SDK](https://github.com/xmtp/xmtp-js). When a developer builds with the SDK, their app embeds an XMTP message API client, which communicates with a message API in an XMTP node to handle all XMTP network interactions required to enable their users to send and receive messages. To learn more, see [XMTP node diagram](#xmtp-node-diagram).
-
-With XMTP network interactions handled by the message API client, developers can focus on the user-related aspects of building client apps, such as:
-
-* User acquisition
-* User interface
-* User identity metadata
-* Inbox filtering  
-To learn about one developer's approach, see [Truths Not Spoofs](https://blog.xmtp.com/truths-not-spoofs/).
-* Custom content types  
-To learn more, see [Content types](content-types).
-
-Developers can also help shape XMTP by participating in [XMTP Improvement Proposals (XIPs)](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) and [contributing](contributing) to XMTP SDKs and tools.
+* [Network layer](network-layer)
+* [App layer](app-layer)

--- a/docs/dev-concepts/client-layer.md
+++ b/docs/dev-concepts/client-layer.md
@@ -15,7 +15,7 @@ At the most basic level, the architecture of XMTP (Extensible Message Transport 
 
 This topic provides an overview of the client layer of XMTP.
 
-The client layer consists of XMTP message API clients (clients) embedded in client apps built with the XMTP client SDK. A message API client connects to the message API in an arbitrary XMTP node to communicate with the network, as shown in the [XMTP node diagram](#xmtp-node-diagram).
+The client layer consists of XMTP message API clients (clients) embedded in client apps built with the XMTP client SDK. A message API client connects to the message API in an arbitrary XMTP node to communicate with the network. To learn more, see [Network layer](network-layer).
 
 The primary responsibilities of a client are to:
 

--- a/docs/dev-concepts/content-types.mdx
+++ b/docs/dev-concepts/content-types.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Content types
-sidebar_position: 4
+sidebar_position: 8
 ---
 import Feedback from '/src/components/Feedback'
 

--- a/docs/dev-concepts/contributing.md
+++ b/docs/dev-concepts/contributing.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Contribute
-sidebar_position: 10
+sidebar_position: 12
 ---
 
 # Contribute to XMTP

--- a/docs/dev-concepts/faq.md
+++ b/docs/dev-concepts/faq.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: FAQ
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # FAQ about XMTP

--- a/docs/dev-concepts/introduction.md
+++ b/docs/dev-concepts/introduction.md
@@ -57,9 +57,9 @@ A user can send and receive encrypted XMTP messages using an app with an embedde
 
 Clients and nodes are implemented as [Waku2](https://rfc.vac.dev/spec/10/) peers but with XMTP-specific functions and capabilities.
 
-To learn more about clients, see [Client layer](architectural-overview#client-layer).
+To learn more about clients, see [Client layer](client-layer).
 
-To learn more about nodes, see [Network layer](architectural-overview#network-layer).
+To learn more about nodes, see [Network layer](network-layer).
 
 
 ## XMTP client SDK

--- a/docs/dev-concepts/invitation-and-message-encryption.md
+++ b/docs/dev-concepts/invitation-and-message-encryption.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Invitation and message encryption
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Invitation and message encryption with XMTP

--- a/docs/dev-concepts/invitation-and-message-encryption.md
+++ b/docs/dev-concepts/invitation-and-message-encryption.md
@@ -58,7 +58,7 @@ Likewise, this sequence diagram illustrates the message decryption and message v
 
 ## XMTP V1 message encryption
 
-This section describes how message encryption works for XMTP V1. To understand whether a client app will use XMTP V1 or V2, see [Determining whether to use XMTP V2 or V1 topics](architectural-overview#determining-whether-to-use-xmtp-v2-or-v1-topics).
+This section describes how message encryption works for XMTP V1. To understand whether a client app will use XMTP V1 or V2, see [Determining whether to use XMTP V2 or V1 topics](client-layer#determining-whether-to-use-xmtp-v2-or-v1-topics).
 
 With XMTP V1 message encryption, a client app encrypts and decrypts messages using the following artifacts:
 

--- a/docs/dev-concepts/key-generation-and-usage.md
+++ b/docs/dev-concepts/key-generation-and-usage.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Key generation and usage
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Key generation and usage in XMTP

--- a/docs/dev-concepts/network-layer.md
+++ b/docs/dev-concepts/network-layer.md
@@ -21,8 +21,6 @@ The XMTP network enables any computer running XMTP node software to participate 
 
 This diagram shows the key components of an XMTP node:
 
-<a name="xmtp-node-diagram"></a>
-
 ![Diagram showing three nodes connected in a peer-to-peer fashion to form the XMTP network. The diagram shows the key components of a node, including a message API and Waku node. The diagram also shows a client app connecting a message API client to the message API in a node.](img/xmtp-nodes.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=16%3A502](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=16%3A502)-->
 
 The nodes provide a **message API** that enables client apps built with the XMTP client SDK to communicate with the XMTP network.
@@ -31,7 +29,7 @@ The nodes use Waku node software to connect to other nodes and form a peer-to-pe
 
 Currently, nodes are configured to rate limit high-volume publishing from message API clients. A rate-limited message API client can expect to receive a 429 status code response from node. Rate limits can change at any time in the interest of maintaining network health.
 
-In the network layer, an **envelope** contains a payload, often encrypted, that is not observable by nodes. The payload could be a public key bundle, private key bundle, or a message created by a client app, but this information is opaque to nodes. Meaning is assigned to these envelopes in the [Client layer](#client-layer).
+In the network layer, an **envelope** contains a payload, often encrypted, that is not observable by nodes. The payload could be a public key bundle, private key bundle, or a message created by a client app, but this information is opaque to nodes. Meaning is assigned to these envelopes in the [Client layer](client-layer).
 
 Nodes can see envelope properties which help the nodes understand how to handle envelopes but the properties reveal nothing about message content. An example of an important envelope property is a **topic** name. A topic name is a required envelope property. A topic name helps a node understand where to relay and store the envelope. Each envelope belongs to exactly one topic.
 

--- a/docs/dev-concepts/network-layer.md
+++ b/docs/dev-concepts/network-layer.md
@@ -29,7 +29,7 @@ The nodes provide a **message API** that enables client apps built with the XMTP
 
 The nodes use Waku node software to connect to other nodes and form a peer-to-peer network to relay and store envelopes submitted and requested by client apps.
 
-Currently, nodes are configured to rate limit high-volume publishing from message API clients. Rate limits can change at any time. The message API returns a 429 status code to a rate-limited message API client.
+Currently, nodes are configured to rate limit high-volume publishing from message API clients. A rate-limited message API client can expect to receive a 429 status code response from node. Rate limits can change at any time in the interest of maintaining network health.
 
 In the network layer, an **envelope** contains a payload, often encrypted, that is not observable by nodes. The payload could be a public key bundle, private key bundle, or a message created by a client app, but this information is opaque to nodes. Meaning is assigned to these envelopes in the [Client layer](#client-layer).
 

--- a/docs/dev-concepts/network-layer.md
+++ b/docs/dev-concepts/network-layer.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: Network layer
+sidebar_position: 3
+---
+
+# Network layer of XMTP
+
+At the most basic level, the architecture of XMTP (Extensible Message Transport Protocol) includes three layers:
+
+* Network layer
+* Client layer
+* App layer
+
+![Diagram showing three layers of the XMTP architecture: network, client, and app.](img/arch-layers.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=0%3A1](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=0%3A1)-->
+
+This topic provides an overview of the network layer of XMTP.
+
+The network layer provides the XMTP network which is comprised of **nodes** (computers) running XMTP node software.
+
+The XMTP network enables any computer running XMTP node software to participate in the network. Currently, the node software is closed source and all nodes in the XMTP network are operated by XMTP Labs. XMTP Labs is working toward a phased decentralization of the network and will share a roadmap in the coming months.
+
+This diagram shows the key components of an XMTP node:
+
+<a name="xmtp-node-diagram"></a>
+
+![Diagram showing three nodes connected in a peer-to-peer fashion to form the XMTP network. The diagram shows the key components of a node, including a message API and Waku node. The diagram also shows a client app connecting a message API client to the message API in a node.](img/xmtp-nodes.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=16%3A502](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=16%3A502)-->
+
+The nodes provide a **message API** that enables client apps built with the XMTP client SDK to communicate with the XMTP network.
+
+The nodes use Waku node software to connect to other nodes and form a peer-to-peer network to relay and store envelopes submitted and requested by client apps.
+
+Currently, nodes are configured to rate limit high-volume publishing from message API clients. Rate limits can change at any time. The message API returns a 429 status code to a rate-limited message API client.
+
+In the network layer, an **envelope** contains a payload, often encrypted, that is not observable by nodes. The payload could be a public key bundle, private key bundle, or a message created by a client app, but this information is opaque to nodes. Meaning is assigned to these envelopes in the [Client layer](#client-layer).
+
+Nodes can see envelope properties which help the nodes understand how to handle envelopes but the properties reveal nothing about message content. An example of an important envelope property is a **topic** name. A topic name is a required envelope property. A topic name helps a node understand where to relay and store the envelope. Each envelope belongs to exactly one topic.
+
+The primary responsibilities of an XMTP node are to:
+
+* Connect to other nodes, forming a peer-to-peer network
+* Advertise information about all of the nodes it’s connected to, enabling newly joined nodes to connect to other nodes in the XMTP network
+* Relay envelopes to other nodes
+* Store envelopes in topics
+* Make envelopes available for retrieval by client apps
+
+<!--To learn more about the XMTP network layer, nodes, and topics, see Network Layer in The XMTP Protocol specifications.-->
+
+Here’s a high-level view of how XMTP nodes relay and store envelopes containing payloads submitted and retrieved by client apps built with XMTP:
+
+![Animation showing the flow of a user sending a message to another user, including how the sender's client app encrypts and submits the message to the XMTP network, how an XMTP node relays the message to other nodes, and how the recipient's client app retrieves the message from the network, decrypts it, and delivers it to the recipient.](img/xmtp-message-flow.gif)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=1%3A169](https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?node-id=1%3A169)--><!--change paper icons to open vs closed envelopes-->
+
+## Learn more
+
+* [Client layer](client-layer)
+* [App layer](app-layer)

--- a/docs/dev-concepts/signatures.md
+++ b/docs/dev-concepts/signatures.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Signatures
-sidebar_position: 9
+sidebar_position: 10
 slug: signatures
 ---
 

--- a/docs/dev-concepts/wallets.md
+++ b/docs/dev-concepts/wallets.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Wallet app and chain support
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Wallet apps and blockchains supported by XMTP

--- a/docs/dev-concepts/xips.mdx
+++ b/docs/dev-concepts/xips.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_label: XMTP Improvement Proposals
-sidebar_position: 11
+sidebar_position: 13
 ---
 import Feedback from '/src/components/Feedback'
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -199,8 +199,16 @@ const config = {
                 to: `/docs/dev-concepts/introduction`,
               },
               {
-                label: `Architectural overview`,
-                to: `/docs/dev-concepts/architectural-overview`,
+                label: `Network layer`,
+                to: `/docs/dev-concepts/network-layer`,
+              },
+              {
+                label: `Client layer`,
+                to: `/docs/dev-concepts/client-layer`,
+              },
+              {
+                label: `App layer`,
+                to: `/docs/dev-concepts/app-layer`,
               },
               {
                 label: `FAQ`,


### PR DESCRIPTION
Break Architectural overview up into multiple pages - one-per-layer - to help reveal more information in the sidebar/left nav