### PR TITLE
Added meta image so twitter can render preview card

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,6 +91,7 @@ const config = {
         defaultMode:'light',
         disableSwitch: false,
       },
+      image: '/img/mobile-animation-bg.jpg',
       navbar: {
         title: '',
         logo: {


### PR DESCRIPTION
## Describe your changes
Twitter doesn't properly render URL Preview card for XMTP.org. I changed our config file to include a default image when image scraper crawls through our page

Information found here: https://docusaurus.io/docs/next/api/themes/configuration#meta-image

## Before
<img width="588" alt="Screen Shot 2022-12-05 at 8 26 29 AM" src="https://user-images.githubusercontent.com/92274722/205696386-13d10598-2290-4076-9c51-f8450e84cb4b.png">

## After
<img width="579" alt="Screen Shot 2022-12-05 at 8 23 21 AM" src="https://user-images.githubusercontent.com/92274722/205696380-9763bce3-d7bd-405f-b25d-18c977bca1b5.png">
