### PR TITLE
Clarify Signatures page URL and left nav topic title

### DIFF
--- a/docs/dev-concepts/faq.md
+++ b/docs/dev-concepts/faq.md
@@ -89,19 +89,19 @@ There are no message storage and retrieval-related fees incurred by developers f
 
 Blockchain accounts sign and advertise a set of keys that XMTP uses to establish a shared secret for encryption using another blockchain account’s keys. These keys attest to the authenticity of both accounts and are required to add messages to their conversation. No third-party apps or relayers are involved in this process.
 
-To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](signatures).
+To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](account-signatures).
 
 ### Does each blockchain account address have a corresponding XMTP identity?
 
 Yes. Each blockchain account address is represented by an XMTP identity key. This identity key is a part of a key bundle that only that the address can use to authenticate messages.
 
-To learn more about XMTP identities, see [Sign to send and receive messages using apps built with XMTP](signatures).
+To learn more about XMTP identities, see [Sign to send and receive messages using apps built with XMTP](account-signatures).
 
 ### Do apps built with XMTP need to decrypt messages with blockchain account private keys each time?
 
 When a user starts a new messaging session with an app built with XMTP, the user must sign with their blockchain account private key to decrypt their XMTP key bundle, which is then used for message decryption. A one-time signature is also required to create that key bundle, which includes an XMTP identity.
 
-To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](signatures).
+To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](account-signatures).
 
 ## Storage
 
@@ -181,4 +181,4 @@ The XMTP SDK currently requires you to use [ethers](https://ethers.org/) or anot
 
 The XMTP client provided by the SDK requires a user's signature in order to decrypt their XMTP message encryption keys. This process must be repeated when starting a new session since there is no secure place in the browser to persist decrypted keys. Based on developer and community feedback, we are researching more robust approaches to secure key management.
 
-To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](signatures).
+To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](account-signatures).

--- a/docs/dev-concepts/key-generation-and-usage.md
+++ b/docs/dev-concepts/key-generation-and-usage.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 The XMTP client protocol supports the generation of keys that enable client apps to establish secure, unfalsifiable relationships between their users' blockchain accounts. These keys also enable client apps to ensure that only the sender and recipient can encrypt and decrypt messages sent between them.
 
-To learn more about user authentication, see [Sign to send and receive messages using apps built with XMTP](signatures).
+To learn more about user authentication, see [Sign to send and receive messages using apps built with XMTP](account-signatures).
 
 To learn more about message encryption, see [Invitation and message encryption with XMTP](invitation-and-message-encryption).
 

--- a/docs/dev-concepts/signatures.md
+++ b/docs/dev-concepts/signatures.md
@@ -1,18 +1,18 @@
 ---
-sidebar_label: Signatures
+sidebar_label: Account signatures
 sidebar_position: 9
-slug: signatures
+slug: account-signatures
 ---
 
 # Sign to send and receive messages using apps built with XMTP
 
-The first time you use an app built with XMTP (Extensible Message Transport Protocol) to send and receive messages using a blockchain account (account), you’re prompted to provide two signatures using your account:
+The first time you use an app built with XMTP (Extensible Message Transport Protocol) to send and receive messages using a blockchain account (account), you’re prompted to provide two signatures using your account keys:
 
 1. [Sign to create an XMTP identity](#sign-to-create-an-xmtp-identity): This is like creating a messaging account associated with your blockchain account.
 
 2. [Sign to enable an XMTP identity](#sign-to-enable-an-xmtp-identity): This is like entering a password to access your messaging account.
 
-Providing these signatures doesn’t cost you any Ether.
+Providing these signatures with your account keys doesn’t cost you any Ether.
 
 Let’s dive deeper into the details of what happens behind the scenes when you provide these signatures.
 
@@ -46,7 +46,7 @@ Once you’ve successfully signed to create an XMTP identity, you’ll never be 
 
 ## Sign to enable an XMTP identity
 
-After you’ve signed to create an XMTP identity (first-time only) and anytime you start a new messaging session using an app built with XMTP, you’re prompted to sign to enable your XMTP identity.
+After you’ve signed to create an XMTP identity (first-time only) and anytime you start a new messaging session using an app built with XMTP, you’re prompted to sign with your account keys to enable your XMTP identity.
 
 For example, here’s the Coinbase Wallet **Signature requested** window that displays when connecting to the XMTP Chat app:
 
@@ -54,7 +54,7 @@ For example, here’s the Coinbase Wallet **Signature requested** window that di
 
 When you click **Sign**, you're providing a secret, like a password, that enables you to access your messages on the XMTP network.
 
-More precisely, you're using your account keys to sign the randomly generated string of bytes shown in the **Message** section of the signature request window. Signing the string generates a secret that only you, as the controller of your account, can generate. By enabling you to sign to generate this secret, XMTP shields you from having to maintain a password.
+More precisely, you're using your account keys to sign the randomly generated string of bytes shown in the **Message** section of the signature request window. Signing the string generates a secret that only you, as the controller of your account, can generate. By enabling you to sign with your account keys to generate this secret, XMTP shields you from having to maintain a password.
 
 The first time you sign to enable an XMTP identity, XMTP uses this secret to encrypt your XMTP identity’s private keys and then stores the encrypted keys on the XMTP network.
 

--- a/docs/dev-concepts/wallets.md
+++ b/docs/dev-concepts/wallets.md
@@ -27,7 +27,7 @@ You can generate multiple XMTP identities from the same wallet app by changing t
 
 :::
 
-To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](signatures).
+To learn more about signatures, see [Sign to send and receive messages using apps built with XMTP](account-signatures).
 
 ## Chains
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -224,8 +224,8 @@ const config = {
                 to: `/docs/dev-concepts/wallets`,
               },
               {
-                label: `Signatures`,
-                to: `/docs/dev-concepts/signatures`,
+                label: `Account signatures`,
+                to: `/docs/dev-concepts/account-signatures`,
               },
               {
                 label: `Contribute to XMTP`,


### PR DESCRIPTION
- Martin provided some insightful feedback that this URL `https://xmtp.org/docs/dev-concepts/signatures` and its 
"Signatures" page title in the left nav may be too generic. He suggested that as-is, just calling it "Signatures" in the left name is so generic that people might think the topic is about signatures inside a message, for example.
- For this reason, we're suggesting that we update the URL to something like `https://xmtp.org/docs/dev-concepts/account-signatures` and the left nav topic name to something like "Account signatures" to help make it clearer that this topic is about how a user needs to use their account keys to provide the signatures XMTP needs to create and enable their XMTP identity.
- Preview here: https://junk-range-possible-git-update-signatures-url-xmtp-labs.vercel.app/docs/dev-concepts/account-signatures

# CREATE URL REDIRECTS

This PR changes a URL. After merging this PR:

- Update the two existing URL redirects for `https://xmtp.org/signatures` and `https://xmtp.org/signatures/` to point to the new target URL defined by this PR: `https://xmtp.org/docs/dev-concepts/account-signatures`
- Create two new URL redirects for `https://xmtp.org/docs/dev-concepts/signatures` and `https://xmtp.org/docs/dev-concepts/signatures/` to point to the new target URL defined by this PR: `https://xmtp.org/docs/dev-concepts/account-signatures`