### PR TITLE
Add a "Careers at XMTP Labs" link to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -289,6 +289,10 @@ const config = {
                 label: 'XMTP code of conduct',
                 to: '/community/code-of-conduct',
               },
+              {
+                label: 'Careers at XMTP Labs',
+                href: 'https://blog.xmtp.com/careers/',
+              },
             ],
           },
           {


### PR DESCRIPTION
Ashley suggested that it might be helpful to point people to the XMTP Labs Career page from the footer of xmtp.org.

Preview here: https://junk-range-possible-git-add-careers-link-xmtp-labs.vercel.app/

This is relevant especially based on our recent redirect of xmtp.com to xmtp.org. xmtplabs.com is not showing up in search results yet because there are few to no links to it from web properties. While we work on updating relevant links to point to xmtplabs.com, I agree with Ashely that adding this link to the footer will be helpful to members of the community who might want to contribute by working at XMTP Labs.

Yes, we make a clear separation between .com and .org, but often the Careers .com URL is the one URL surfaced on .org sites.

I put it in the Community column as it seemed to be the most relevant category. I am hesitant to add another column such as "About XMTP Labs", for example - but can do it if folx think this is too big a miscategorization. 

Another option might be to add the link to the bottom of the footer to the right of the "Terms of Service" link. 

Any thoughts?

J-Ha is following up with Ashley for her approval.