### PR TITLE
Fix anchor links

### DIFF
--- a/docs/client-sdk/javascript/tutorials/use-content-types.mdx
+++ b/docs/client-sdk/javascript/tutorials/use-content-types.mdx
@@ -48,7 +48,8 @@ You can use `xmtp-js` to specify and send a custom content type beyond the prede
 
     The receiving client uses the `contentType` value of `ContentTypeNumber` to identify the content type of the `3.14` message sent through the `send` API. If the receiving client supports the content type, it displays the message. If it doesn't support the content type, it displays the fall-back plaintext.
 
-    To learn more about the `send` API, see [sendMessage](/docs/client-sdk/javascript/reference/classes/Client#sendmessage).
+    To learn more about the `send` API, see [Sending messages](quickstart#sending-messages).
+    <!--reference docs are now missing the pre-existing sendMessage topic: https://xmtp.org/docs/client-sdk/javascript/reference/classes/Client#sendmessage. We have an open eng issue to fix this. In the meantime,linking here.-->
 
 To learn more about sending new content types, see [Different content types](https://github.com/xmtp/xmtp-js/blob/4157fadd80bce80c8094135f3e47d3856515468f/README.md#different-types-of-content).
 

--- a/docs/dev-concepts/invitation-and-message-encryption.md
+++ b/docs/dev-concepts/invitation-and-message-encryption.md
@@ -12,10 +12,10 @@ All XMTP invitations and messages are encrypted.
 
 This section describes how invitation and message encryption work for XMTP V2. Only client apps with XMTP client SDK >=v7.0.0 can use XMTP V2.
 
-To learn more about invitations and messages, see [XMTP V2 topics and message presentation flow](#xmtp-v2-topics-and-message-presentation-flow).
+To learn more about invitations and messages, see [XMTP V2 topics and message presentation flow](architectural-overview#xmtp-v2-topics-and-message-presentation-flow).
 <!--once specs are published, add link to Client Layer in The XMTP Protocol specifications.-->
 
-To learn about how invitation and message encryption work in XMTP V1, see [XMTP V1 message encryption](#xmtp-v1-topics-and-message-presentation-flow).
+To learn about how invitation and message encryption work in XMTP V1, see [XMTP V1 message encryption](#xmtp-v1-message-encryption).
 
 
 ### Invitation encryption

--- a/docs/dev-concepts/invitation-and-message-encryption.md
+++ b/docs/dev-concepts/invitation-and-message-encryption.md
@@ -10,7 +10,7 @@ All XMTP invitations and messages are encrypted.
 
 ## XMTP V2 invitation and message encryption
 
-This section describes how invitation and message encryption work for XMTP V2. Only client apps with XMTP client SDK >=v7.0.0 can use XMTP V2.
+This section describes how invitation and message encryption work for XMTP V2. Only client apps with XMTP client SDK >=v7.0.0 can use XMTP V2. 
 
 To learn more about invitations and messages, see [XMTP V2 topics and message presentation flow](architectural-overview#xmtp-v2-topics-and-message-presentation-flow).
 <!--once specs are published, add link to Client Layer in The XMTP Protocol specifications.-->


### PR DESCRIPTION
- Fixes https://github.com/xmtp/xmtp-dot-org/issues/205. Docusaurus doesn't check for broken anchor links. Static site generators I've worked with in the past perform this check so I thought everything was OK! I should have verified. There is an open Docusaurus issue about this missing functionality: https://github.com/facebook/docusaurus/issues/3321
- I will look into possibly using `remark-validate-links` for our site to avoid broken anchor links.
- In the meantime, I've done a manual check and all anchor links are working now.