### PR TITLE
Clarify that the xmtp.org authorityId is reserved for standard content types

### DIFF
--- a/docs/client-sdk/javascript/tutorials/use-content-types.mdx
+++ b/docs/client-sdk/javascript/tutorials/use-content-types.mdx
@@ -7,8 +7,6 @@ sidebar_position: 4
 
 All messages in XMTP are encoded with a **content type** to ensure interoperability and consistency of experience across the XMTP network.
 
-To learn more about content types, see [Content types with XMTP](/docs/dev-concepts/content-types).
-
 Two standard content types come bundled with the XMTP client SDK:
 
 1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plain text content  
@@ -29,6 +27,8 @@ Do not use `xmtp.org` as the `authorityId` for a custom content type that you cr
 
 To learn more about `authorityId` and other parameters in a content type identifier, see [Content Type Identifier and Parameters](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#content-type-identifier-and-parameters).
 
+To learn more about content types, see [Content types with XMTP](/docs/dev-concepts/content-types).
+
 ## Send plain text messages using the `TextCodec` standard content type
 
 An app built with XMTP uses the `TextCodec` (plain text) standard content type by default. This means that if your app is sending plain text messages only, you don’t need to perform any additional steps related to content types.
@@ -39,7 +39,7 @@ If you want your app to be able to send multiple content types; such as any comb
 
 :::info
 
-While XMTP supports the `CompositeCodec` standard content type, you must ensure that the app reading the composite message supports the content types used in the composite.
+While XMTP supports the `CompositeCodec` standard content type, the app reading the composite message must support the content types used in the composite message to be able to display them.
 
 :::
 

--- a/docs/client-sdk/javascript/tutorials/use-content-types.mdx
+++ b/docs/client-sdk/javascript/tutorials/use-content-types.mdx
@@ -19,11 +19,15 @@ Two standard content types come bundled with the XMTP client SDK:
 
    To learn more about this composite content type, see [XIP-9](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-9-composite-content-type.md).
 
-:::important
+For standard content types, `xmtp.org` is the `authorityId`. Only standard content types adopted through the XMTP Improvement Proposal (XIP) process can use `xmtp.org` as their `authorityId`.
 
-For standard content types, `xmtp.org` is the `authorityId`. Only standard content types adopted through the XIP process can use `xmtp.org` as their `authorityId`. A custom content type that you create for your app must not use `xmtp.org` as an `authorityId`. Instead, consider using a unique DNS domain or ENS name (e.g. uniswap.eth). To learn more about `authorityId` and other parameters in a content type identifier, see [Content Type Identifier and Parameters](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#content-type-identifier-and-parameters).
+:::caution
+
+ A custom content type that you create for your app must not use `xmtp.org` as an `authorityId`. Instead, consider using a DNS domain or ENS name (e.g. uniswap.eth). 
 
 :::
+
+To learn more about `authorityId` and other parameters in a content type identifier, see [Content Type Identifier and Parameters](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#content-type-identifier-and-parameters).
 
 ## Send plain text messages using the TextCodec standard content type
 
@@ -33,7 +37,7 @@ An app built with XMTP uses the `TextCodec` (plain text) standard content type b
 
 If you want your app to be able to send multiple content types; such as any combination of plain text, images, audio, and video; in a single message, you must set up your app to use the `CompositeCodec` standard content type.
 
-:::important
+:::info
 
 While XMTP supports the `CompositeCodec` standard content type, you must ensure that the app reading the composite message supports the content types used in the composite.
 
@@ -61,6 +65,14 @@ const xmtp = Client.create(wallet, { codecs: [new CompositeCodec()] })
 
 You can use `xmtp-js` to specify and send a custom content type beyond the standard `TextCodec` and `CompositeCodec` content types.
 
+:::caution
+
+ A custom content type that you create for your app must not use `xmtp.org` as an `authorityId`. Instead, consider using a DNS domain or ENS name (e.g. uniswap.eth). 
+
+:::
+
+To learn more about `authorityId` and other parameters in a content type identifier, see [Content Type Identifier and Parameters](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#content-type-identifier-and-parameters).
+
 **To send a custom content type:**
 
 1. Specify a custom content type to enable during client initialization.
@@ -77,7 +89,7 @@ You can use `xmtp-js` to specify and send a custom content type beyond the stand
 
     This snippet registers the `NumberCodec` custom content type with the sending client. During the registration process, the sending client automatically associates the codec with the content type it says it supports. For example, `NumberCodec` might say that it supports the `ContentTypeNumber` content type.
 
-2. Send a message using the specified custom content type and fall-back plaintext.
+2. Send a message using the specified custom content type and fall-back plain text.
 
     ```typescript
     // Assuming NumberCodec can be used to encode numbers and is
@@ -88,9 +100,9 @@ You can use `xmtp-js` to specify and send a custom content type beyond the stand
     })
     ```
 
-    This example sends a message using the fictional "number" custom content type, including fall-back plaintext.
+    This example sends a message using the fictional "number" custom content type, including fall-back plain text.
 
-    The receiving client uses the `contentType` value of `ContentTypeNumber` to identify the content type of the `3.14` message sent through the `send` API. If the receiving client supports the content type, it displays the message. If it doesn't support the content type, it displays the fall-back plaintext.
+    The receiving client uses the `contentType` value of `ContentTypeNumber` to identify the content type of the `3.14` message sent through the `send` API. If the receiving client supports the content type, it displays the message. If it doesn't support the content type, it displays the fall-back plain text.
 
     To learn more about the `send` API, see [Sending messages](quickstart#sending-messages).
     <!--reference docs are now missing the pre-existing sendMessage topic: https://xmtp.org/docs/client-sdk/javascript/reference/classes/Client#sendmessage. We have an open eng issue to fix this. In the meantime,linking here.-->

--- a/docs/client-sdk/javascript/tutorials/use-content-types.mdx
+++ b/docs/client-sdk/javascript/tutorials/use-content-types.mdx
@@ -2,7 +2,6 @@
 sidebar_label: Use content types
 sidebar_position: 4
 ---
-import Feedback from '/src/components/Feedback'
 
 # Use content types
 
@@ -10,19 +9,64 @@ All messages in XMTP are encoded with a **content type** to ensure interoperabil
 
 To learn more about content types, see [Content types with XMTP](/docs/dev-concepts/content-types).
 
-Two predefined content types come bundled with the XMTP client SDK:
+Two standard content types come bundled with the XMTP client SDK:
 
-1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plaintext content
-2. `xtmp.org/composite:1.0`, which defines an **optional** `CompositeCodec` for multiple content types in a single message
+1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plain text content  
 
-You can use `xmtp-js` to specify and send a custom content type beyond the predefined `TextCodec` and `CompositeCodec` content types.
+   To learn more about this text content type, see [XIP-5](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#xmtporgtext).
+
+2. `xtmp.org/composite:1.0`, which defines an **optional** `CompositeCodec` for multiple content types in a single message  
+
+   To learn more about this composite content type, see [XIP-9](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-9-composite-content-type.md).
+
+:::important
+
+For standard content types, `xmtp.org` is the `authorityId`. Only standard content types adopted through the XIP process can use `xmtp.org` as their `authorityId`. A custom content type that you create for your app must not use `xmtp.org` as an `authorityId`. Instead, consider using a unique DNS domain or ENS name (e.g. uniswap.eth). To learn more about `authorityId` and other parameters in a content type identifier, see [Content Type Identifier and Parameters](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#content-type-identifier-and-parameters).
+
+:::
+
+## Send plain text messages using the TextCodec standard content type
+
+An app built with XMTP uses the `TextCodec` (plain text) standard content type by default. This means that if your app is sending plain text messages only, you don’t need to perform any additional steps related to content types.
+
+## Send multiple content types in a message using the CompositeCodec standard content type
+
+If you want your app to be able to send multiple content types; such as any combination of plain text, images, audio, and video; in a single message, you must set up your app to use the `CompositeCodec` standard content type.
+
+:::important
+
+While XMTP supports the `CompositeCodec` standard content type, you must ensure that the app reading the composite message supports the content types used in the composite.
+
+:::
+
+### Import the `CompositeCodec` standard content type
+
+Import the `CompositeCodec` content type from the `xmtp-js` client SDK to make it available in your app. For example:
+
+```javascript
+import { CompositeCodec } from '@xmtp/xmtp-js'
+```
+
+### Tag a message with the `CompositeCodec` standard content type
+
+To enable a message API client to know to use the `CompositeCodec` content type to encode and decode a message, tag the message with the content type.
+
+To do this, pass the `CompositeCodec` content type as an option to the `Client.create()` method. This configures the message API client instance to use `CompositeCodec` when encoding and decoding messages. For example:
+
+```javascript
+const xmtp = Client.create(wallet, { codecs: [new CompositeCodec()] })
+```
+
+## Send a custom content type
+
+You can use `xmtp-js` to specify and send a custom content type beyond the standard `TextCodec` and `CompositeCodec` content types.
 
 **To send a custom content type:**
 
 1. Specify a custom content type to enable during client initialization.
 
     ```typescript
-    // Adding support for a fictional `xmtp.org/number` content type
+    // Adding support for a fictional `frenz.xyz/number` content type
     import { NumberCodec } from '@xmtp/xmtp-js'
     const xmtp = Client.create(wallet, { codecs: [new NumberCodec()] })
     ```
@@ -51,6 +95,4 @@ You can use `xmtp-js` to specify and send a custom content type beyond the prede
     To learn more about the `send` API, see [Sending messages](quickstart#sending-messages).
     <!--reference docs are now missing the pre-existing sendMessage topic: https://xmtp.org/docs/client-sdk/javascript/reference/classes/Client#sendmessage. We have an open eng issue to fix this. In the meantime,linking here.-->
 
-To learn more about sending new content types, see [Different content types](https://github.com/xmtp/xmtp-js/blob/4157fadd80bce80c8094135f3e47d3856515468f/README.md#different-types-of-content).
-
-<Feedback url="https://github.com/orgs/xmtp/discussions/categories/q-a"/>
+To learn more about sending custom content types, see [Different content types](https://github.com/xmtp/xmtp-js/blob/4157fadd80bce80c8094135f3e47d3856515468f/README.md#different-types-of-content).

--- a/docs/client-sdk/javascript/tutorials/use-content-types.mdx
+++ b/docs/client-sdk/javascript/tutorials/use-content-types.mdx
@@ -21,7 +21,7 @@ For these standard content types, `xmtp.org` is the `authorityId` value. `xmtp.o
 
 :::caution
 
-Do not use `xmtp.org` as the `authorityId` for a custom content type that you create for your app.
+Do not use `xmtp.org` as the `authorityId` for a custom content type that you create for your app. Instead, consider using a unique DNS domain or ENS name that can be widely recognized as belonging to your app. For example, `frenz.xyz`.
 
 :::
 

--- a/docs/client-sdk/javascript/tutorials/use-content-types.mdx
+++ b/docs/client-sdk/javascript/tutorials/use-content-types.mdx
@@ -19,21 +19,21 @@ Two standard content types come bundled with the XMTP client SDK:
 
    To learn more about this composite content type, see [XIP-9](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-9-composite-content-type.md).
 
-For standard content types, `xmtp.org` is the `authorityId`. Only standard content types adopted through the XMTP Improvement Proposal (XIP) process can use `xmtp.org` as their `authorityId`.
+For these standard content types, `xmtp.org` is the `authorityId` value. `xmtp.org` is reserved for use as the `authorityId` for standard content types. Standard content types are those that have been adopted through the [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) (XIP) process.
 
 :::caution
 
- A custom content type that you create for your app must not use `xmtp.org` as an `authorityId`. Instead, consider using a DNS domain or ENS name (e.g. uniswap.eth). 
+Do not use `xmtp.org` as the `authorityId` for a custom content type that you create for your app.
 
 :::
 
 To learn more about `authorityId` and other parameters in a content type identifier, see [Content Type Identifier and Parameters](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-5-message-content-types.md#content-type-identifier-and-parameters).
 
-## Send plain text messages using the TextCodec standard content type
+## Send plain text messages using the `TextCodec` standard content type
 
 An app built with XMTP uses the `TextCodec` (plain text) standard content type by default. This means that if your app is sending plain text messages only, you don’t need to perform any additional steps related to content types.
 
-## Send multiple content types in a message using the CompositeCodec standard content type
+## Send multiple content types in a message using the `CompositeCodec` standard content type
 
 If you want your app to be able to send multiple content types; such as any combination of plain text, images, audio, and video; in a single message, you must set up your app to use the `CompositeCodec` standard content type.
 
@@ -67,7 +67,7 @@ You can use `xmtp-js` to specify and send a custom content type beyond the stand
 
 :::caution
 
- A custom content type that you create for your app must not use `xmtp.org` as an `authorityId`. Instead, consider using a DNS domain or ENS name (e.g. uniswap.eth). 
+Do not use `xmtp.org` as the `authorityId` for a custom content type that you create for your app. `xmtp.org` is reserved for use as the `authorityId` for standard content types only.
 
 :::
 

--- a/docs/dev-concepts/content-types.mdx
+++ b/docs/dev-concepts/content-types.mdx
@@ -10,16 +10,16 @@ All messages in XMTP are encoded with a **content type** to ensure interoperabil
 
 Message **payloads** are transported as a set of bytes. This means that payloads can carry any content type that a client supports, such as plain text, JSON, or even non-text binary or media content.
 
-The XMTP SDK allows developers to adopt new custom content types and put them to immediate use without going through a formal process. Client apps might choose to adopt those content types if they want to render those message types, but they can also rely on fall-back plain text.
-
-Fall-back plain text is "alt text"-like description text that you can associate with original content if you are concerned that the receiving client app might not be able to handle the original content. If the receiving client app is unable to handle the original content, it displays the fall-back plain text instead.
-
 Two standard content types come bundled with the XMTP client SDK:
 
-1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plain text content
-2. `xtmp.org/composite:1.0`, which defines an **optional** `CompositeCodec` for multiple content types in a single message
+- Text: Handles plain text
+- Composite: Handles multiple content types in a single message
 
-The client SDK adopted these standard content types through the [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) process, which enables a [framework](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-5-message-content-types.md) for community members to propose standards and achieve consensus about their adoption.
+The XMTP client SDK adopted these standard content types through the [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) (XIP) process, which enables a [framework](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-5-message-content-types.md) for community members to propose standards and achieve consensus about their adoption.
+
+The SDK also allows developers to create custom content types and put them to immediate use without going through a formal XIP adoption process. Client apps can adopt these custom content types if they want to render those message types, but they can also rely on fall-back plain text.
+
+Fall-back plain text is "alt text"-like description text that you can associate with original content if you are concerned that the receiving client app might not be able to handle the original content. If the receiving client app is unable to handle the original content, it displays the fall-back plain text instead.
 
 To learn how to use standard and custom content types when developing a client app, see [Use content types](/docs/client-sdk/javascript/tutorials/use-content-types).
 

--- a/docs/dev-concepts/content-types.mdx
+++ b/docs/dev-concepts/content-types.mdx
@@ -16,7 +16,7 @@ Fall-back plain text is "alt text"-like description text that you can associate 
 
 Two standard content types come bundled with the XMTP client SDK:
 
-1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plaintext content
+1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plain text content
 2. `xtmp.org/composite:1.0`, which defines an **optional** `CompositeCodec` for multiple content types in a single message
 
 The client SDK adopted these standard content types through the [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) process, which enables a [framework](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-5-message-content-types.md) for community members to propose standards and achieve consensus about their adoption.

--- a/docs/dev-concepts/content-types.mdx
+++ b/docs/dev-concepts/content-types.mdx
@@ -10,19 +10,17 @@ All messages in XMTP are encoded with a **content type** to ensure interoperabil
 
 Message **payloads** are transported as a set of bytes. This means that payloads can carry any content type that a client supports, such as plain text, JSON, or even non-text binary or media content.
 
-The XMTP SDK allows developers to adopt new content types and put them to immediate use without going through a formal process. Client apps might choose to adopt those content types if they want to render those message types, but they can also rely on fall-back plain text.
+The XMTP SDK allows developers to adopt new custom content types and put them to immediate use without going through a formal process. Client apps might choose to adopt those content types if they want to render those message types, but they can also rely on fall-back plain text.
 
 Fall-back plain text is "alt text"-like description text that you can associate with original content if you are concerned that the receiving client app might not be able to handle the original content. If the receiving client app is unable to handle the original content, it displays the fall-back plain text instead.
 
-Two predefined content types come bundled with the XMTP client SDK:
+Two standard content types come bundled with the XMTP client SDK:
 
 1. `xmtp.org/text:1.0`, which defines a **default** `TextCodec` for plaintext content
 2. `xtmp.org/composite:1.0`, which defines an **optional** `CompositeCodec` for multiple content types in a single message
 
-The client SDK adopted these content types through the [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) process, which enables a [framework](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-5-message-content-types.md) for community members to propose standards and achieve consensus about their adoption.
+The client SDK adopted these standard content types through the [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) process, which enables a [framework](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-5-message-content-types.md) for community members to propose standards and achieve consensus about their adoption.
 
-To learn more about content types, see [Different types of content](https://github.com/xmtp/xmtp-js/tree/0ec6b344cb69823e5c4c924f35d1262b51fa636e#different-types-of-content).
-
-To learn how to use content types when developing a client app, see [Use content types](/docs/client-sdk/javascript/tutorials/use-content-types).
+To learn how to use standard and custom content types when developing a client app, see [Use content types](/docs/client-sdk/javascript/tutorials/use-content-types).
 
 <Feedback url="https://github.com/orgs/xmtp/discussions/categories/q-a"/>


### PR DESCRIPTION
Preview: https://junk-range-possible-git-authorityid-info-xmtp-labs.vercel.app/docs/client-sdk/javascript/tutorials/use-content-types

- While we're here - I also added the seemingly "uncontroversial" "Send plain text messages using the `TextCodec` standard content type" and "Send multiple content types in a message using the `CompositeCodec` standard content type" sections  from this draft: https://www.notion.so/xmtplabs/Encoding-and-decoding-messages-with-XMTP-8fe7fdc460114a1f9eefde7823e476eb?pvs=4 -- too much too soon?

- Full coverage of creating custom content types will come later through Rich's work on the topic.