### PR TITLE
Add code syntax highlighting for dart, swift, and kotlin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -410,6 +410,7 @@ const config = {
         //... other Algolia params
       },
       prism: {
+        additionalLanguages: ['dart', 'swift', 'kotlin'],
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },


### PR DESCRIPTION
- Also tried to add `gradle`, but not working even if listed as a [Prism language](https://prismjs.com/#supported-languages) supported by Docusaurus. It's just a one-line code block in Kotlin, so not a huge impact.