### PR TITLE
Add "Get started building with XMTP"

### DIFF
--- a/docs/dev-concepts/architectural-overview.md
+++ b/docs/dev-concepts/architectural-overview.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Architectural overview
-sidebar_position: 2
+sidebar_position: 2.5
 toc_max_heading_level: 4
 ---
 import Feedback from '/src/components/Feedback'

--- a/docs/dev-concepts/introduction.md
+++ b/docs/dev-concepts/introduction.md
@@ -13,7 +13,7 @@ XMTP's extensible design enables a diverse set of use cases for sending message 
 - **App-to-user** notifications
 - **Creator-to-community** announcements
 
-Because the XMTP network persists messages, and those messages are tied to web3 identities as opposed to a specific client app, each web3 identity has a **portable inbox** of that it can access using any client app built with XMTP.
+Because the XMTP network persists messages, and those messages are tied to web3 identities as opposed to a specific client app, each web3 identity has an [**interoperable inbox**](interoperable-inbox) of that it can access using any client app built with XMTP.
 
 Developers can also build tools for decentralized apps (dapps), decentralized autonomous organizations (DAOs), creators, and protocols to re-engage users with web3 messaging.
 

--- a/docs/dev-concepts/start-building.md
+++ b/docs/dev-concepts/start-building.md
@@ -7,20 +7,20 @@ sidebar_position: 2
 
 XMTP is an open protocol and network for secure web3 messaging. Developers build with XMTP client SDKs to provide messaging between blockchain accounts in their apps. The XMTP messaging API client takes care of:
 
-- [Authentication](https://xmtp.org/docs/dev-concepts/account-signatures) using an **XMTP identity that the user owns and controls**
+- [Authentication](account-signatures) using an **XMTP identity that the user owns and controls**
 
-- [End-to-end encryption](https://xmtp.org/docs/dev-concepts/invitation-and-message-encryption) of **messages that the user owns and controls**
+- [End-to-end encryption](invitation-and-message-encryption) of **messages that the user owns and controls**
 
-- Providing an **[interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox)** accessible across apps built with XMTP
+- Providing an **[interoperable inbox](interoperable-inbox)** accessible across apps built with XMTP
 
-- Relaying messages to the **progressively decentralized** [XMTP network](https://xmtp.org/docs/dev-concepts/architectural-overview#network-layer)
+- Relaying messages to the **progressively decentralized** [XMTP network](architectural-overview#network-layer)
 
 Here’s a list of high-level steps and considerations to help you get started building with XMTP.
 
 
 ## Try messaging with an app built with XMTP
 
-1. [**Start messaging with XMTP**](https://xmtp.org/docs/client-sdk/javascript/tutorials/start-messaging)
+1. [**Start messaging with XMTP**](/docs/client-sdk/javascript/tutorials/start-messaging)
     
     Use an app built with XMTP to start learning how to build one.
     
@@ -36,7 +36,7 @@ Here’s a list of high-level steps and considerations to help you get started b
 
 ## Start building your app
 
-1. [**Build a simple hello world app**](https://xmtp.org/docs/client-sdk/javascript/tutorials/build-an-xmtp-hello-world-app)
+1. [**Build a simple hello world app**](/docs/client-sdk/javascript/tutorials/build-an-xmtp-hello-world-app)
     
     Get a feel for building with XMTP by building an app using 100% copy-and-paste commands and code.
     
@@ -46,15 +46,14 @@ Here’s a list of high-level steps and considerations to help you get started b
     - [xmtp-android](https://github.com/xmtp/xmtp-android)
     - [xmtp-ios](https://github.com/xmtp/xmtp-ios)
     - [xmtp-flutter](https://github.com/xmtp/xmtp-flutter)
-    - Create your own XMTP messaging bot using [xmtp-bot-starter](https://github.com/xmtp/xmtp-bot-starter)
 
 3. **Want to provide DMs in a Lens app?**
 
-    To learn how, see [Build key XMTP chat features in a Lens app](https://xmtp.org/docs/client-sdk/javascript/tutorials/build-key-xmtp-chat-features-in-a-lens-app).
+    To learn how, see [Build key XMTP chat features in a Lens app](/docs/client-sdk/javascript/tutorials/build-key-xmtp-chat-features-in-a-lens-app).
     
     Need a Lens handle? Message `prxshant.eth` using [xmtp.chat](https://xmtp.chat/)
     
-4. [**Follow UX best practices**](https://xmtp.org/docs/dev-concepts/ux-best-practices)
+4. [**Follow UX best practices**](ux-best-practices)
 
 5. **Explore example apps for implementation guidance and inspiration:**
 
@@ -67,7 +66,7 @@ Here’s a list of high-level steps and considerations to help you get started b
     - [xmtp-inbox-web](https://github.com/xmtp-labs/xmtp-inbox-web)  
     An example app that showcases innovative ways of building with XMTP.
         
-    - [Built with XMTP](https://xmtp.org/built-with-xmtp)  
+    - [Built with XMTP](/built-with-xmtp/)  
     Explore a curated showcase of apps built with XMTP.
         
     - [Awesome XMTP](https://github.com/xmtp/awesome-xmtp)  
@@ -86,7 +85,7 @@ Here’s a list of high-level steps and considerations to help you get started b
 
 - **Want to provide more than plain text messages?**  
 
-  By default, building with XMTP SDKs supports plain text messages. If you’d like to provide other types of content in messages, you’ll use content types. To learn more, see [Content types](https://xmtp.org/docs/dev-concepts/content-types), [Use content types](https://xmtp.org/docs/client-sdk/javascript/tutorials/use-content-types), and [Some new content types](https://xmtp.org/blog/attachments-and-remote-attachments).
+  By default, building with XMTP SDKs supports plain text messages. If you’d like to provide other types of content in messages, you’ll use content types. To learn more, see [Content types](content-types), [Use content types](/docs/client-sdk/javascript/tutorials/use-content-types), and [Some new content types](/blog/attachments-and-remote-attachments).
     
 - **Want to speed up conversation load time?**  
 
@@ -100,7 +99,7 @@ Here’s a list of high-level steps and considerations to help you get started b
     
 - **Want to filter conversations?**  
 
-  By default, building with XMTP SDKs lists all conversations a user has regardless of which app started the conversation. This concept is called an [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox). If you want to provide filtered views of the user’s interoperable inbox, you can [use conversation filters](/docs/client-sdk/javascript/tutorials/filter-conversations).
+  By default, building with XMTP SDKs lists all conversations a user has regardless of which app started the conversation. This concept is called an [interoperable inbox](interoperable-inbox). If you want to provide filtered views of the user’s interoperable inbox, you can [use conversation filters](/docs/client-sdk/javascript/tutorials/filter-conversations).
     
 - **Want to label conversations?**  
 
@@ -143,7 +142,7 @@ Here’s a list of high-level steps and considerations to help you get started b
 
 - **Have a public goods project you want to build that fosters XMTP ecosystem growth?**  
 
-  - Apply for an [XMTP grant](https://xmtp.org/grants).
+  - Apply for an [XMTP grant](/grants).
     
 - **Is there something your app needs that the protocol doesn’t currently support?**  
 

--- a/docs/dev-concepts/start-building.md
+++ b/docs/dev-concepts/start-building.md
@@ -17,6 +17,7 @@ XMTP is an open protocol and network for secure web3 messaging. Developers build
 
 Here’s a list of high-level steps and considerations to help you get started building with XMTP.
 
+
 ## Try messaging with an app built with XMTP
 
 1. [**Start messaging with XMTP**](https://xmtp.org/docs/client-sdk/javascript/tutorials/start-messaging)
@@ -30,7 +31,7 @@ Here’s a list of high-level steps and considerations to help you get started b
         
     - `hi.xmtp.eth` (0x194c31cAe1418D5256E8c58e0d08Aee1046C6Ed0)  
     
-        Message the XMTP Labs team and a human will reply, though not as immediately as gm.xmtp.eth! 🤖
+        Message the XMTP Labs team and a human will reply, though not as quickly as `gm.xmtp.eth`! 🤖
         
 
 ## Start building your app
@@ -49,7 +50,7 @@ Here’s a list of high-level steps and considerations to help you get started b
 
 3. **Want to provide DMs in a Lens app?**
 
-    See [Build key XMTP chat features in a Lens app](https://xmtp.org/docs/client-sdk/javascript/tutorials/build-key-xmtp-chat-features-in-a-lens-app).
+    To learn how, see [Build key XMTP chat features in a Lens app](https://xmtp.org/docs/client-sdk/javascript/tutorials/build-key-xmtp-chat-features-in-a-lens-app).
     
     Need a Lens handle? Message `prxshant.eth` using [xmtp.chat](https://xmtp.chat/)
     
@@ -58,10 +59,10 @@ Here’s a list of high-level steps and considerations to help you get started b
 5. **Explore example apps for implementation guidance and inspiration:**
 
     - [https://demo.xmtp.chat/](https://demo.xmtp.chat/)  
-    When you open the app, it creates a burner Ethereum account and connects it to the app. It also creates and enables an XMTP identity for the account. And you’re ready to send demo messages with XMTP! The burner account is “burned” as soon as the demo session ends.
+    When you open the app, it creates a burner Ethereum account and connects it to the app. The app also creates and enables an XMTP identity for the account. And you’re ready to send demo messages with XMTP! The burner account is “burned” as soon as the demo session ends.
         
     - [xmtp-quickstart-react](https://github.com/xmtp/xmtp-quickstart-react)  
-    An intentionally lightweight example app that you can use as a developer tool to learn how to build with XMTP.
+    An intentionally lightweight example app that you can use to learn how to build with XMTP.
         
     - [xmtp-inbox-web](https://github.com/xmtp-labs/xmtp-inbox-web)  
     An example app that showcases innovative ways of building with XMTP.
@@ -72,11 +73,14 @@ Here’s a list of high-level steps and considerations to help you get started b
     - [Awesome XMTP](https://github.com/xmtp/awesome-xmtp)  
     Explore a list of project repos using XMTP.
         
-6. **You probably have some great questions by now. Check out these resources:**
+6. **You probably have some great questions by now! Check out these resources:**
 
-    - [FAQ about XMTP](https://xmtp.org/docs/dev-concepts/faq)
-    - [Join and learn with the XMTP community](https://xmtp.org/community)
-    - [XMTP blog](https://xmtp.org/blog)
+    - [FAQ](faq)
+    - [Join and learn with the XMTP community](/community)
+    - [Blog](/blog)
+    - [Roadmap](/vision/roadmap)
+    - [Litepaper - public draft](/vision/litepaper)
+
 
 ## Refine your app
 
@@ -86,7 +90,7 @@ Here’s a list of high-level steps and considerations to help you get started b
     
 - **Want to speed up conversation load time?**  
 
-  For users with large numbers of conversations, loading conversations in real-time can be a very expensive operation. You can use a persistent conversation cache to improve load time. To learn more, see [Use a persistent conversation cache](https://xmtp.org/docs/client-sdk/javascript/tutorials/use-a-persistent-conversation-cache).
+  For users with large numbers of conversations, loading conversations in real-time can be a very expensive operation. You can [use a persistent conversation cache](/docs/client-sdk/javascript/tutorials/use-a-persistent-conversation-cache) to improve load time.
     
 - **Want to provide push notifications?**  
 
@@ -96,17 +100,16 @@ Here’s a list of high-level steps and considerations to help you get started b
     
 - **Want to filter conversations?**  
 
-  By default, building with XMTP SDKs lists all conversations a user has regardless of which app started the conversation. This concept is called an [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox).
-
-    If you want to provide a filtered view of the user’s interoperable inbox, you can use filters. To learn more, see [Filter conversations](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
+  By default, building with XMTP SDKs lists all conversations a user has regardless of which app started the conversation. This concept is called an [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox). If you want to provide filtered views of the user’s interoperable inbox, you can [use conversation filters](/docs/client-sdk/javascript/tutorials/filter-conversations).
     
 - **Want to label conversations?**  
 
-  When you display a user’s full interoperable inbox, the user may see multiple ongoing conversations they are having with another address. To help clarify the UX for users, provide conversation labels. To learn more, see [Label conversations](https://xmtp.org/docs/client-sdk/javascript/tutorials/label-conversations).
+  When you display a user’s full interoperable inbox, the user may see multiple ongoing conversations they are having with another address. To help clarify the UX for users, [use conversation labels](/docs/client-sdk/javascript/tutorials/label-conversations).
     
 - **Want app feedback from XMTP Labs?**  
 
   Message `prxshant.eth` using [xmtp.chat](https://xmtp.chat/) with a link to your demo video or TestFlight.
+
 
 ## Launch your app
 
@@ -122,7 +125,7 @@ Here’s a list of high-level steps and considerations to help you get started b
 
   - See the [XMTP Brand Guidelines](https://github.com/xmtp/brand)
     
-- **Tag the XMTP Labs team to help amplify your launch.**
+- **Tag the XMTP Labs team to help amplify your launch**
 
   - [@xmtplabs](https://lenster.xyz/u/xmtplabs) on Lens
   - [@xmtp_](https://twitter.com/xmtp_) on Twitter

--- a/docs/dev-concepts/start-building.md
+++ b/docs/dev-concepts/start-building.md
@@ -1,0 +1,147 @@
+---
+sidebar_label: Start building
+sidebar_position: 2
+---
+
+# Get started building with XMTP
+
+XMTP is an open protocol and network for secure web3 messaging. Developers build with XMTP client SDKs to provide messaging between blockchain accounts in their apps. The XMTP messaging API client takes care of:
+
+- [Authentication](https://xmtp.org/docs/dev-concepts/account-signatures) using an **XMTP identity that the user owns and controls**
+
+- [End-to-end encryption](https://xmtp.org/docs/dev-concepts/invitation-and-message-encryption) of **messages that the user owns and controls**
+
+- Providing an **[interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox)** accessible across apps built with XMTP
+
+- Relaying messages to the **progressively decentralized** [XMTP network](https://xmtp.org/docs/dev-concepts/architectural-overview#network-layer)
+
+Here’s a list of high-level steps and considerations to help you get started building with XMTP.
+
+## Try messaging with an app built with XMTP
+
+1. [**Start messaging with XMTP**](https://xmtp.org/docs/client-sdk/javascript/tutorials/start-messaging)
+    
+    Use an app built with XMTP to start learning how to build one.
+    
+2. **Need someone to send a test message to?**
+    - `gm.xmtp.eth` (0x937C0d4a6294cdfa575de17382c7076b579DC176)  
+    
+        Message this XMTP message bot to get an immediate automated reply. 
+        
+    - `hi.xmtp.eth` (0x194c31cAe1418D5256E8c58e0d08Aee1046C6Ed0)  
+    
+        Message the XMTP Labs team and a human will reply, though not as immediately as gm.xmtp.eth! 🤖
+        
+
+## Start building your app
+
+1. [**Build a simple hello world app**](https://xmtp.org/docs/client-sdk/javascript/tutorials/build-an-xmtp-hello-world-app)
+    
+    Get a feel for building with XMTP by building an app using 100% copy-and-paste commands and code.
+    
+2. **Ready to build your own app? Start with an XMTP client SDK:**
+
+    - [xmtp-js](https://github.com/xmtp/xmtp-js)
+    - [xmtp-android](https://github.com/xmtp/xmtp-android)
+    - [xmtp-ios](https://github.com/xmtp/xmtp-ios)
+    - [xmtp-flutter](https://github.com/xmtp/xmtp-flutter)
+    - Create your own XMTP messaging bot using [xmtp-bot-starter](https://github.com/xmtp/xmtp-bot-starter)
+
+3. **Want to provide DMs in a Lens app?**
+
+    See [Build key XMTP chat features in a Lens app](https://xmtp.org/docs/client-sdk/javascript/tutorials/build-key-xmtp-chat-features-in-a-lens-app).
+    
+    Need a Lens handle? Message `prxshant.eth` using [xmtp.chat](https://xmtp.chat/)
+    
+4. [**Follow UX best practices**](https://xmtp.org/docs/dev-concepts/ux-best-practices)
+
+5. **Explore example apps for implementation guidance and inspiration:**
+
+    - [https://demo.xmtp.chat/](https://demo.xmtp.chat/)  
+    When you open the app, it creates a burner Ethereum account and connects it to the app. It also creates and enables an XMTP identity for the account. And you’re ready to send demo messages with XMTP! The burner account is “burned” as soon as the demo session ends.
+        
+    - [xmtp-quickstart-react](https://github.com/xmtp/xmtp-quickstart-react)  
+    An intentionally lightweight example app that you can use as a developer tool to learn how to build with XMTP.
+        
+    - [xmtp-inbox-web](https://github.com/xmtp-labs/xmtp-inbox-web)  
+    An example app that showcases innovative ways of building with XMTP.
+        
+    - [Built with XMTP](https://xmtp.org/built-with-xmtp)  
+    Explore a curated showcase of apps built with XMTP.
+        
+    - [Awesome XMTP](https://github.com/xmtp/awesome-xmtp)  
+    Explore a list of project repos using XMTP.
+        
+6. **You probably have some great questions by now. Check out these resources:**
+
+    - [FAQ about XMTP](https://xmtp.org/docs/dev-concepts/faq)
+    - [Join and learn with the XMTP community](https://xmtp.org/community)
+    - [XMTP blog](https://xmtp.org/blog)
+
+## Refine your app
+
+- **Want to provide more than plain text messages?**  
+
+  By default, building with XMTP SDKs supports plain text messages. If you’d like to provide other types of content in messages, you’ll use content types. To learn more, see [Content types](https://xmtp.org/docs/dev-concepts/content-types), [Use content types](https://xmtp.org/docs/client-sdk/javascript/tutorials/use-content-types), and [Some new content types](https://xmtp.org/blog/attachments-and-remote-attachments).
+    
+- **Want to speed up conversation load time?**  
+
+  For users with large numbers of conversations, loading conversations in real-time can be a very expensive operation. You can use a persistent conversation cache to improve load time. To learn more, see [Use a persistent conversation cache](https://xmtp.org/docs/client-sdk/javascript/tutorials/use-a-persistent-conversation-cache).
+    
+- **Want to provide push notifications?**  
+
+  See the [example-notification-server-go](https://github.com/xmtp/example-notification-server-go) for an example push notification server written in Golang that you can use as a reference for how you might provide a server for your app.  
+
+    For Android apps, see [Enable the example app to send push notifications](https://github.com/xmtp/xmtp-android/blob/main/library/src/main/java/org/xmtp/android/library/push/README.md).
+    
+- **Want to filter conversations?**  
+
+  By default, building with XMTP SDKs lists all conversations a user has regardless of which app started the conversation. This concept is called an [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox).
+
+    If you want to provide a filtered view of the user’s interoperable inbox, you can use filters. To learn more, see [Filter conversations](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
+    
+- **Want to label conversations?**  
+
+  When you display a user’s full interoperable inbox, the user may see multiple ongoing conversations they are having with another address. To help clarify the UX for users, provide conversation labels. To learn more, see [Label conversations](https://xmtp.org/docs/client-sdk/javascript/tutorials/label-conversations).
+    
+- **Want app feedback from XMTP Labs?**  
+
+  Message `prxshant.eth` using [xmtp.chat](https://xmtp.chat/) with a link to your demo video or TestFlight.
+
+## Launch your app
+
+- **Check out these launch posts for other apps built with XMTP:**
+
+    - [Orb](https://twitter.com/orbapp_/status/1618659601154715649?s=20)
+    - [meTokens](https://twitter.com/meTokens/status/1597983759462436870?s=20&t=wHy9mBrNR5ri146CbhCMUw)
+    - [Buttrfly](https://twitter.com/0xMoe_/status/1603126849852563456?s=20&t=wHy9mBrNR5ri146CbhCMUw)
+    - [Lenster](https://twitter.com/lensterxyz/status/1588203593257009152?s=20&t=wHy9mBrNR5ri146CbhCMUw)
+    - [LensPort](https://twitter.com/lensport_io/status/1602370688139939841?s=20&t=wHy9mBrNR5ri146CbhCMUw)
+
+- **Need an XMTP logo for your announcement?**  
+
+  - See the [XMTP Brand Guidelines](https://github.com/xmtp/brand)
+    
+- **Tag the XMTP Labs team to help amplify your launch.**
+
+  - [@xmtplabs](https://lenster.xyz/u/xmtplabs) on Lens
+  - [@xmtp_](https://twitter.com/xmtp_) on Twitter
+    
+- **Have your app added to [Built with XMTP](https://xmtp.org/built-with-xmtp)**  
+
+  - [Submit this form](https://forms.gle/p1VgVtkoGfHXANXt5)
+    
+- **Have your project repo added to [awesome-xmtp](https://github.com/xmtp/awesome-xmtp)**  
+
+  - [Create a PR](https://github.com/xmtp/awesome-xmtp)
+    
+
+## Contribute to XMTP
+
+- **Have a public goods project you want to build that fosters XMTP ecosystem growth?**  
+
+  - Apply for an [XMTP grant](https://xmtp.org/grants).
+    
+- **Is there something your app needs that the protocol doesn’t currently support?**  
+
+  - Consider creating an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/ae6fc638332f57f918d82a096f69b1e79df0bd0a/XIPs/xip-0-purpose-process.md) (XIP). Here’s a [template](https://github.com/xmtp/XIPs/blob/main/xip-template.md) you can use to create one.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,6 +132,7 @@ const config = {
             to: 'docs/dev-concepts/start-building',
             position: 'right',
             label: '⚡️ Start building ⚡️',
+            className: 'start-building_link',
           },
           {
             type: 'dropdown',
@@ -270,6 +271,10 @@ const config = {
               {
                 label: `Intro to XMTP`,
                 to: `/docs/dev-concepts/introduction`,
+              },
+              {
+                label: `Start building`,
+                to: `/docs/dev-concepts/start-building`,
               },
               {
                 label: `Architectural overview`,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,12 +129,6 @@ const config = {
         },
         items: [
           {
-            to: 'docs/dev-concepts/start-building',
-            position: 'right',
-            label: '⚡️ Start building ⚡️',
-            className: 'start-building_link',
-          },
-          {
             type: 'dropdown',
             label: 'Documentation',
             position: 'right',
@@ -232,6 +226,12 @@ const config = {
             position: 'right',
             label: 'Blog',
             activeBaseRegex: `/`,
+          },
+          {
+            to: 'docs/dev-concepts/start-building',
+            position: 'right',
+            label: '⚡️ Start building ⚡️',
+            className: 'start-building_link',
           },
           {
             href: 'https://github.com/xmtp',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,6 +129,11 @@ const config = {
         },
         items: [
           {
+            to: 'docs/dev-concepts/start-building',
+            position: 'right',
+            label: '⚡️ Start building ⚡️',
+          },
+          {
             type: 'dropdown',
             label: 'Documentation',
             position: 'right',

--- a/src/components/MainContent/index.js
+++ b/src/components/MainContent/index.js
@@ -214,7 +214,7 @@ export const MainContent = ({ styles }) => {
                   </dl>
 
                   <Link
-                    to="/docs/client-sdk/javascript/tutorials/quickstart"
+                    to="/docs/dev-concepts/start-building"
                     className="bg-red-500 text-white border-none rounded-lg py-3 px-5 font-bold text-base w-44 mt-10 h-12 cursor-pointer hover:bg-red-600 mb-14 xl:mb-0 block hover:no-underline hover:text-white"
                   >
                     <img

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -354,6 +354,10 @@
   font-weight: 600;
 }
 
+.start-building_link {
+  font-weight: bold;
+}
+
 .table-of-contents__left-border {
   border: none;
   padding-left: 0;


### PR DESCRIPTION
Preview: https://junk-range-possible-git-add-get-started-xmtp-labs.vercel.app/docs/dev-concepts/start-building

- Add "Get started building with XMTP" to Dev concepts
- Add prominent link to it in the top nav. This is where we want people to get started.
  - The lightly styled link front and center is the best I could do without design and eng help. =) If we are OK with it as action > perfection, we can request design and eng help with providing a button in the upper right as suggested by Yash in the near future.
- Also linked to the page from the Build with XMTP - Start building button on the home page.
- Once this gets merged, I'll also update each SDK quickstart and README with a link to this doc.  