### PR TITLE
Update xmtp-js ref docs to reflect v8

### DIFF
--- a/docs/client-sdk/javascript/reference/classes/Ciphertext.md
+++ b/docs/client-sdk/javascript/reference/classes/Ciphertext.md
@@ -1,0 +1,70 @@
+<!---->
+# Class: Ciphertext
+
+## Implements
+
+- `Ciphertext`
+
+## Constructors
+
+### constructor
+
+**new Ciphertext**(`obj`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `obj` | `Ciphertext` |
+
+#### Defined in
+
+[crypto/Ciphertext.ts:14](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Ciphertext.ts#L14)
+
+## Properties
+
+### aes256GcmHkdfSha256
+
+ **aes256GcmHkdfSha256**: `undefined` \| `Ciphertext_Aes256gcmHkdfsha256`
+
+#### Implementation of
+
+ciphertext.Ciphertext.aes256GcmHkdfSha256
+
+#### Defined in
+
+[crypto/Ciphertext.ts:12](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Ciphertext.ts#L12)
+
+## Methods
+
+### toBytes
+
+**toBytes**(): `Uint8Array`
+
+#### Returns
+
+`Uint8Array`
+
+#### Defined in
+
+[crypto/Ciphertext.ts:36](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Ciphertext.ts#L36)
+
+___
+
+### fromBytes
+
+`Static` **fromBytes**(`bytes`): [`Ciphertext`](Ciphertext.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `bytes` | `Uint8Array` |
+
+#### Returns
+
+[`Ciphertext`](Ciphertext.md)
+
+#### Defined in
+
+[crypto/Ciphertext.ts:40](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Ciphertext.ts#L40)

--- a/docs/client-sdk/javascript/reference/classes/Client.md
+++ b/docs/client-sdk/javascript/reference/classes/Client.md
@@ -8,20 +8,32 @@ Should be created with `await Client.create(options)`
 
 ### constructor
 
-**new Client**(`keys`, `apiClient`)
+**new Client**(`publicKeyBundle`, `apiClient`, `backupClient`, `keystore`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `keys` | `PrivateKeyBundleV1` |
+| `publicKeyBundle` | [`PublicKeyBundle`](PublicKeyBundle.md) |
 | `apiClient` | `default` |
+| `backupClient` | `default` |
+| `keystore` | [`Keystore`](../interfaces/Keystore.md) |
 
 #### Defined in
 
-[Client.ts:158](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L158)
+[Client.ts:220](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L220)
 
 ## Properties
+
+### \_backupClient
+
+ `Private` **\_backupClient**: `default`
+
+#### Defined in
+
+[Client.ts:214](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L214)
+
+___
 
 ### \_codecs
 
@@ -29,7 +41,7 @@ Should be created with `await Client.create(options)`
 
 #### Defined in
 
-[Client.ts:155](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L155)
+[Client.ts:217](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L217)
 
 ___
 
@@ -39,7 +51,7 @@ ___
 
 #### Defined in
 
-[Client.ts:153](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L153)
+[Client.ts:215](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L215)
 
 ___
 
@@ -49,7 +61,7 @@ ___
 
 #### Defined in
 
-[Client.ts:156](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L156)
+[Client.ts:218](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L218)
 
 ___
 
@@ -59,7 +71,7 @@ ___
 
 #### Defined in
 
-[Client.ts:143](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L143)
+[Client.ts:204](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L204)
 
 ___
 
@@ -69,7 +81,7 @@ ___
 
 #### Defined in
 
-[Client.ts:146](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L146)
+[Client.ts:206](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L206)
 
 ___
 
@@ -79,17 +91,17 @@ ___
 
 #### Defined in
 
-[Client.ts:147](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L147)
+[Client.ts:207](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L207)
 
 ___
 
-### keys
+### keystore
 
- **keys**: `PrivateKeyBundleV2`
+ **keystore**: [`Keystore`](../interfaces/Keystore.md)
 
 #### Defined in
 
-[Client.ts:145](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L145)
+[Client.ts:205](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L205)
 
 ___
 
@@ -99,19 +111,33 @@ ___
 
 #### Defined in
 
-[Client.ts:148](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L148)
+[Client.ts:209](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L209)
 
 ___
 
-### legacyKeys
+### publicKeyBundle
 
- **legacyKeys**: `PrivateKeyBundleV1`
+ **publicKeyBundle**: [`PublicKeyBundle`](PublicKeyBundle.md)
 
 #### Defined in
 
-[Client.ts:144](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L144)
+[Client.ts:208](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L208)
 
 ## Accessors
+
+### backupType
+
+`get` **backupType**(): `BackupType`
+
+#### Returns
+
+`BackupType`
+
+#### Defined in
+
+[Client.ts:249](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L249)
+
+___
 
 ### conversations
 
@@ -123,7 +149,21 @@ ___
 
 #### Defined in
 
-[Client.ts:176](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L176)
+[Client.ts:245](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L245)
+
+___
+
+### signedPublicKeyBundle
+
+`get` **signedPublicKeyBundle**(): [`SignedPublicKeyBundle`](SignedPublicKeyBundle.md)
+
+#### Returns
+
+[`SignedPublicKeyBundle`](SignedPublicKeyBundle.md)
+
+#### Defined in
+
+[Client.ts:253](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L253)
 
 ## Methods
 
@@ -135,8 +175,8 @@ Check if
 
 **`Peer Address`**
 
-can be messaged, specifically it checks that a PublicKeyBundle can be
-found for the given address
+can be messaged, specifically
+it checks that a PublicKeyBundle can be found for the given address
 
 #### Parameters
 
@@ -150,7 +190,30 @@ found for the given address
 
 #### Defined in
 
-[Client.ts:287](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L287)
+[Client.ts:448](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L448)
+
+**canMessage**(`peerAddress`): `Promise`<`boolean`[]\>
+
+Check if
+
+**`Peer Address`**
+
+can be messaged, specifically
+it checks that a PublicKeyBundle can be found for the given address
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `peerAddress` | `string`[] |
+
+#### Returns
+
+`Promise`<`boolean`[]\>
+
+#### Defined in
+
+[Client.ts:449](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L449)
 
 ___
 
@@ -164,13 +227,16 @@ ___
 
 #### Defined in
 
-[Client.ts:216](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L216)
+[Client.ts:329](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L329)
 
 ___
 
 ### codecFor
 
 **codecFor**(`contentType`): `undefined` \| [`ContentCodec`](../interfaces/ContentCodec.md)<`any`\>
+
+Find a matching codec for a given `ContentTypeId` from the
+client's codec registry
 
 #### Parameters
 
@@ -184,13 +250,16 @@ ___
 
 #### Defined in
 
-[Client.ts:334](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L334)
+[Client.ts:560](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L560)
 
 ___
 
 ### encodeContent
 
 **encodeContent**(`content`, `options?`): `Promise`<`Uint8Array`\>
+
+Convert arbitrary content into a serialized `EncodedContent` instance
+with the given options
 
 #### Parameters
 
@@ -205,7 +274,7 @@ ___
 
 #### Defined in
 
-[Client.ts:346](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L346)
+[Client.ts:576](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L576)
 
 ___
 
@@ -225,7 +294,7 @@ ___
 
 #### Defined in
 
-[Client.ts:220](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L220)
+[Client.ts:333](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L333)
 
 ___
 
@@ -247,7 +316,7 @@ Used to force getUserContact fetch contact from the network.
 
 #### Defined in
 
-[Client.ts:279](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L279)
+[Client.ts:443](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L443)
 
 ___
 
@@ -257,6 +326,9 @@ ___
 
 Returns the cached PublicKeyBundle if one is known for the given address or fetches
 one from the network
+
+This throws if either the address is invalid or the contact is not published.
+See also [#canMessage].
 
 #### Parameters
 
@@ -270,7 +342,29 @@ one from the network
 
 #### Defined in
 
-[Client.ts:255](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L255)
+[Client.ts:370](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L370)
+
+___
+
+### getUserContacts
+
+**getUserContacts**(`peerAddresses`): `Promise`<(`undefined` \| [`SignedPublicKeyBundle`](SignedPublicKeyBundle.md) \| [`PublicKeyBundle`](PublicKeyBundle.md))[]\>
+
+Identical to getUserContact but for multiple peer addresses
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `peerAddresses` | `string`[] |
+
+#### Returns
+
+`Promise`<(`undefined` \| [`SignedPublicKeyBundle`](SignedPublicKeyBundle.md) \| [`PublicKeyBundle`](PublicKeyBundle.md))[]\>
+
+#### Defined in
+
+[Client.ts:394](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L394)
 
 ___
 
@@ -282,7 +376,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `options` | [`ClientOptions`](../modules.md#clientoptions) |
+| `options` | `Flatten`<[`NetworkOptions`](../modules.md#networkoptions) & [`KeyStoreOptions`](../modules.md#keystoreoptions) & [`ContentOptions`](../modules.md#contentoptions) & [`LegacyOptions`](../modules.md#legacyoptions) & `PreEventCallbackOptions`\> |
 
 #### Returns
 
@@ -290,13 +384,19 @@ ___
 
 #### Defined in
 
-[Client.ts:207](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L207)
+[Client.ts:318](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L318)
 
 ___
 
 ### listEnvelopes
 
-**listEnvelopes**<`Out`\>(`topics`, `mapper`, `opts?`): `Promise`<`Out`[]\>
+**listEnvelopes**<`Out`\>(`topic`, `mapper`, `opts?`): `Promise`<`Out`[]\>
+
+List stored messages from the specified topic.
+
+A specified mapper function will be applied to each envelope.
+If the mapper function throws an error during processing, the
+envelope will be discarded.
 
 #### Type parameters
 
@@ -308,7 +408,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `topics` | `string`[] |
+| `topic` | `string` |
 | `mapper` | `EnvelopeMapper`<`Out`\> |
 | `opts?` | [`ListMessagesOptions`](../modules.md#listmessagesoptions) |
 
@@ -318,13 +418,13 @@ ___
 
 #### Defined in
 
-[Client.ts:376](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L376)
+[Client.ts:612](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L612)
 
 ___
 
 ### listEnvelopesPaginated
 
-**listEnvelopesPaginated**<`Out`\>(`contentTopics`, `mapper`, `opts?`): `AsyncGenerator`<`Out`[], `any`, `unknown`\>
+**listEnvelopesPaginated**<`Out`\>(`contentTopic`, `mapper`, `opts?`): `AsyncGenerator`<`Out`[], `any`, `unknown`\>
 
 List messages on a given set of content topics, yielding one page at a time
 
@@ -338,7 +438,7 @@ List messages on a given set of content topics, yielding one page at a time
 
 | Name | Type |
 | :------ | :------ |
-| `contentTopics` | `string`[] |
+| `contentTopic` | `string` |
 | `mapper` | `EnvelopeMapper`<`Out`\> |
 | `opts?` | `ListMessagesPaginatedOptions` |
 
@@ -348,13 +448,13 @@ List messages on a given set of content topics, yielding one page at a time
 
 #### Defined in
 
-[Client.ts:410](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L410)
+[Client.ts:646](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L646)
 
 ___
 
 ### listInvitations
 
-**listInvitations**(`opts?`): `Promise`<`SealedInvitation`[]\>
+**listInvitations**(`opts?`): `Promise`<`Envelope`[]\>
 
 #### Parameters
 
@@ -364,11 +464,11 @@ ___
 
 #### Returns
 
-`Promise`<`SealedInvitation`[]\>
+`Promise`<`Envelope`[]\>
 
 #### Defined in
 
-[Client.ts:367](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L367)
+[Client.ts:597](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L597)
 
 ___
 
@@ -376,11 +476,16 @@ ___
 
 **publishEnvelopes**(`envelopes`): `Promise`<`void`\>
 
+Low level method for publishing envelopes to the XMTP network with
+no pre-processing or encryption applied.
+
+Primarily used internally
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `envelopes` | `PublishParams`[] |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `envelopes` | `PublishParams`[] | PublishParams[] |
 
 #### Returns
 
@@ -388,7 +493,7 @@ ___
 
 #### Defined in
 
-[Client.ts:315](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L315)
+[Client.ts:533](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L533)
 
 ___
 
@@ -408,13 +513,16 @@ ___
 
 #### Defined in
 
-[Client.ts:240](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L240)
+[Client.ts:353](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L353)
 
 ___
 
 ### registerCodec
 
 **registerCodec**(`codec`): `void`
+
+Register a codec to be automatically used for encoding/decoding
+messages of the given Content Type
 
 #### Parameters
 
@@ -428,7 +536,7 @@ ___
 
 #### Defined in
 
-[Client.ts:327](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L327)
+[Client.ts:549](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L549)
 
 ___
 
@@ -448,7 +556,7 @@ ___
 
 #### Defined in
 
-[Client.ts:304](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L304)
+[Client.ts:514](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L514)
 
 ___
 
@@ -461,7 +569,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `peerAddress` | `string` |
-| `opts?` | `Partial`<`NetworkOptions`\> |
+| `opts?` | `Partial`<[`NetworkOptions`](../modules.md#networkoptions)\> |
 
 #### Returns
 
@@ -469,7 +577,24 @@ ___
 
 #### Defined in
 
-[Client.ts:292](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L292)
+[Client.ts:472](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L472)
+
+`Static` **canMessage**(`peerAddress`, `opts?`): `Promise`<`boolean`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `peerAddress` | `string`[] |
+| `opts?` | `Partial`<[`NetworkOptions`](../modules.md#networkoptions)\> |
+
+#### Returns
+
+`Promise`<`boolean`[]\>
+
+#### Defined in
+
+[Client.ts:477](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L477)
 
 ___
 
@@ -483,8 +608,8 @@ Create and start a client associated with given wallet.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `wallet` | ``null`` \| `Signer` | the wallet as a Signer instance |
-| `opts?` | `Partial`<[`ClientOptions`](../modules.md#clientoptions)\> | specify how to to connect to the network |
+| `wallet` | ``null`` \| [`Signer`](../interfaces/Signer.md) | the wallet as a Signer instance |
+| `opts?` | `Partial`<`Flatten`<[`NetworkOptions`](../modules.md#networkoptions) & [`KeyStoreOptions`](../modules.md#keystoreoptions) & [`ContentOptions`](../modules.md#contentoptions) & [`LegacyOptions`](../modules.md#legacyoptions) & `PreEventCallbackOptions`\>\> | specify how to to connect to the network |
 
 #### Returns
 
@@ -492,7 +617,7 @@ Create and start a client associated with given wallet.
 
 #### Defined in
 
-[Client.ts:186](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L186)
+[Client.ts:263](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L263)
 
 ___
 
@@ -500,12 +625,21 @@ ___
 
 `Static` **getKeys**(`wallet`, `opts?`): `Promise`<`Uint8Array`\>
 
+Export the XMTP PrivateKeyBundle from the SDK as a `Uint8Array`.
+
+This bundle can then be provided as `privateKeyOverride` in a
+subsequent call to `Client.create(...)`
+
+Be very careful with these keys, as they can be used to
+impersonate a user on the XMTP network and read the user's
+messages.
+
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `wallet` | ``null`` \| `Signer` |
-| `opts?` | `Partial`<[`ClientOptions`](../modules.md#clientoptions)\> |
+| `wallet` | ``null`` \| [`Signer`](../interfaces/Signer.md) |
+| `opts?` | `Partial`<`Flatten`<[`NetworkOptions`](../modules.md#networkoptions) & [`KeyStoreOptions`](../modules.md#keystoreoptions) & [`ContentOptions`](../modules.md#contentoptions) & [`LegacyOptions`](../modules.md#legacyoptions) & `PreEventCallbackOptions`\>\> |
 
 #### Returns
 
@@ -513,4 +647,25 @@ ___
 
 #### Defined in
 
-[Client.ts:199](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L199)
+[Client.ts:296](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L296)
+
+___
+
+### setupBackupClient
+
+`Static` `Private` **setupBackupClient**(`walletAddress`, `env`): `Promise`<`default`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `walletAddress` | `string` |
+| `env` | ``"local"`` \| ``"dev"`` \| ``"production"`` |
+
+#### Returns
+
+`Promise`<`default`\>
+
+#### Defined in
+
+[Client.ts:305](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L305)

--- a/docs/client-sdk/javascript/reference/classes/CompositeCodec.md
+++ b/docs/client-sdk/javascript/reference/classes/CompositeCodec.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[codecs/Composite.ts:35](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L35)
+[codecs/Composite.ts:35](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L35)
 
 ## Methods
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[codecs/Composite.ts:55](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L55)
+[codecs/Composite.ts:55](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L55)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[codecs/Composite.ts:39](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L39)
+[codecs/Composite.ts:39](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L39)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[codecs/Composite.ts:83](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L83)
+[codecs/Composite.ts:83](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L83)
 
 ___
 
@@ -119,4 +119,4 @@ ___
 
 #### Defined in
 
-[codecs/Composite.ts:62](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L62)
+[codecs/Composite.ts:62](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L62)

--- a/docs/client-sdk/javascript/reference/classes/ContentTypeId.md
+++ b/docs/client-sdk/javascript/reference/classes/ContentTypeId.md
@@ -15,7 +15,7 @@
 
 #### Defined in
 
-[MessageContent.ts:10](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L10)
+[MessageContent.ts:10](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L10)
 
 ## Properties
 
@@ -25,7 +25,7 @@
 
 #### Defined in
 
-[MessageContent.ts:5](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L5)
+[MessageContent.ts:5](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L5)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:6](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L6)
+[MessageContent.ts:6](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L6)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:7](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L7)
+[MessageContent.ts:7](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L7)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:8](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L8)
+[MessageContent.ts:8](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L8)
 
 ## Methods
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:21](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L21)
+[MessageContent.ts:21](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L21)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:17](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L17)
+[MessageContent.ts:17](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L17)

--- a/docs/client-sdk/javascript/reference/classes/Conversations.md
+++ b/docs/client-sdk/javascript/reference/classes/Conversations.md
@@ -17,7 +17,7 @@ Conversations allows you to view ongoing 1:1 messaging sessions with another wal
 
 #### Defined in
 
-[conversations/Conversations.ts:21](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L21)
+[conversations/Conversations.ts:77](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L77)
 
 ## Properties
 
@@ -27,13 +27,101 @@ Conversations allows you to view ongoing 1:1 messaging sessions with another wal
 
 #### Defined in
 
-[conversations/Conversations.ts:20](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L20)
+[conversations/Conversations.ts:73](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L73)
+
+___
+
+### v1Cache
+
+ `Private` **v1Cache**: `ConversationCache`
+
+#### Defined in
+
+[conversations/Conversations.ts:74](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L74)
+
+___
+
+### v2Mutex
+
+ `Private` **v2Mutex**: `Mutex`
+
+#### Defined in
+
+[conversations/Conversations.ts:75](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L75)
 
 ## Methods
 
+### conversationReferenceToV2
+
+`Private` **conversationReferenceToV2**(`convoRef`): `ConversationV2`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `convoRef` | `ConversationReference` |
+
+#### Returns
+
+`ConversationV2`
+
+#### Defined in
+
+[conversations/Conversations.ts:199](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L199)
+
+___
+
+### createV2Convo
+
+`Private` **createV2Convo**(`recipient`, `context?`): `Promise`<`ConversationV2`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `recipient` | [`SignedPublicKeyBundle`](SignedPublicKeyBundle.md) |
+| `context?` | `InvitationContext` |
+
+#### Returns
+
+`Promise`<`ConversationV2`\>
+
+#### Defined in
+
+[conversations/Conversations.ts:495](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L495)
+
+___
+
+### decodeInvites
+
+`Private` **decodeInvites**(`envelopes`, `shouldThrow?`): `Promise`<`ConversationV2`[]\>
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `envelopes` | `Envelope`[] | `undefined` |
+| `shouldThrow` | `boolean` | `false` |
+
+#### Returns
+
+`Promise`<`ConversationV2`[]\>
+
+#### Defined in
+
+[conversations/Conversations.ts:162](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L162)
+
+___
+
 ### getIntroductionPeers
 
-`Private` **getIntroductionPeers**(): `Promise`<`Map`<`string`, `Date`\>\>
+`Private` **getIntroductionPeers**(`opts?`): `Promise`<`Map`<`string`, `Date`\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts?` | [`ListMessagesOptions`](../modules.md#listmessagesoptions) |
 
 #### Returns
 
@@ -41,7 +129,7 @@ Conversations allows you to view ongoing 1:1 messaging sessions with another wal
 
 #### Defined in
 
-[conversations/Conversations.ts:233](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L233)
+[conversations/Conversations.ts:383](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L383)
 
 ___
 
@@ -61,29 +149,73 @@ ___
 
 #### Defined in
 
-[conversations/Conversations.ts:365](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L365)
+[conversations/Conversations.ts:527](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L527)
+
+___
+
+### getV2ConversationsFromKeystore
+
+`Private` **getV2ConversationsFromKeystore**(): `Promise`<`ConversationV2`[]\>
+
+#### Returns
+
+`Promise`<`ConversationV2`[]\>
+
+#### Defined in
+
+[conversations/Conversations.ts:144](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L144)
 
 ___
 
 ### list
 
-**list**(): `Promise`<[`Conversation`](../modules.md#conversation)[]\>
+**list**(): `Promise`<[`Conversation`](../interfaces/Conversation.md)[]\>
 
-List all conversations with the current wallet found in the network, deduped by peer address
+List all conversations with the current wallet found in the network.
 
 #### Returns
 
-`Promise`<[`Conversation`](../modules.md#conversation)[]\>
+`Promise`<[`Conversation`](../interfaces/Conversation.md)[]\>
 
 #### Defined in
 
-[conversations/Conversations.ts:28](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L28)
+[conversations/Conversations.ts:86](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L86)
+
+___
+
+### listV1Conversations
+
+`Private` **listV1Conversations**(): `Promise`<[`Conversation`](../interfaces/Conversation.md)[]\>
+
+#### Returns
+
+`Promise`<[`Conversation`](../interfaces/Conversation.md)[]\>
+
+#### Defined in
+
+[conversations/Conversations.ts:98](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L98)
+
+___
+
+### listV2Conversations
+
+`Private` **listV2Conversations**(): `Promise`<[`Conversation`](../interfaces/Conversation.md)[]\>
+
+List all V2 conversations
+
+#### Returns
+
+`Promise`<[`Conversation`](../interfaces/Conversation.md)[]\>
+
+#### Defined in
+
+[conversations/Conversations.ts:117](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L117)
 
 ___
 
 ### newConversation
 
-**newConversation**(`peerAddress`, `context?`): `Promise`<[`Conversation`](../modules.md#conversation)\>
+**newConversation**(`peerAddress`, `context?`): `Promise`<[`Conversation`](../interfaces/Conversation.md)\>
 
 Creates a new conversation for the given address. Will throw an error if the peer is not found in the XMTP network
 
@@ -96,39 +228,37 @@ Creates a new conversation for the given address. Will throw an error if the pee
 
 #### Returns
 
-`Promise`<[`Conversation`](../modules.md#conversation)\>
+`Promise`<[`Conversation`](../interfaces/Conversation.md)\>
 
 #### Defined in
 
-[conversations/Conversations.ts:270](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L270)
+[conversations/Conversations.ts:427](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L427)
 
 ___
 
-### sendInvitation
+### saveInviteResponseToConversation
 
-`Private` **sendInvitation**(`recipient`, `invitation`, `created`): `Promise`<`SealedInvitation`\>
+`Private` **saveInviteResponseToConversation**(`«destructured»`): `ConversationV2`
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `recipient` | [`SignedPublicKeyBundle`](SignedPublicKeyBundle.md) |
-| `invitation` | `InvitationV1` |
-| `created` | `Date` |
+| `«destructured»` | `SaveInvitesResponse_Response` |
 
 #### Returns
 
-`Promise`<`SealedInvitation`\>
+`ConversationV2`
 
 #### Defined in
 
-[conversations/Conversations.ts:335](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L335)
+[conversations/Conversations.ts:189](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L189)
 
 ___
 
 ### stream
 
-**stream**(): `Promise`<[`Stream`](Stream.md)<[`Conversation`](../modules.md#conversation)\>\>
+**stream**(): `Promise`<[`Stream`](Stream.md)<[`Conversation`](../interfaces/Conversation.md)\>\>
 
 Returns a stream of any newly created conversations.
 Will dedupe to not return the same conversation twice in the same stream.
@@ -136,11 +266,11 @@ Does not dedupe any other previously seen conversations
 
 #### Returns
 
-`Promise`<[`Stream`](Stream.md)<[`Conversation`](../modules.md#conversation)\>\>
+`Promise`<[`Stream`](Stream.md)<[`Conversation`](../interfaces/Conversation.md)\>\>
 
 #### Defined in
 
-[conversations/Conversations.ts:59](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L59)
+[conversations/Conversations.ts:216](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L216)
 
 ___
 
@@ -159,4 +289,24 @@ Callers should be aware the first messages in a newly created conversation are p
 
 #### Defined in
 
-[conversations/Conversations.ts:110](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversations.ts#L110)
+[conversations/Conversations.ts:264](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L264)
+
+___
+
+### updateV2Conversations
+
+**updateV2Conversations**(`startTime?`): `Promise`<`ConversationV2`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `startTime?` | `Date` |
+
+#### Returns
+
+`Promise`<`ConversationV2`[]\>
+
+#### Defined in
+
+[conversations/Conversations.ts:151](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversations.ts#L151)

--- a/docs/client-sdk/javascript/reference/classes/DecodedMessage.md
+++ b/docs/client-sdk/javascript/reference/classes/DecodedMessage.md
@@ -5,17 +5,17 @@
 
 ### constructor
 
-**new DecodedMessage**(`__namedParameters`)
+**new DecodedMessage**(`«destructured»`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `__namedParameters` | [`DecodedMessage`](DecodedMessage.md) |
+| `«destructured»` | `Omit`<[`DecodedMessage`](DecodedMessage.md), ``"toBytes"``\> |
 
 #### Defined in
 
-[Message.ts:259](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L259)
+[Message.ts:244](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L244)
 
 ## Properties
 
@@ -25,7 +25,17 @@
 
 #### Defined in
 
-[Message.ts:256](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L256)
+[Message.ts:240](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L240)
+
+___
+
+### contentBytes
+
+ **contentBytes**: `Uint8Array`
+
+#### Defined in
+
+[Message.ts:242](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L242)
 
 ___
 
@@ -35,7 +45,7 @@ ___
 
 #### Defined in
 
-[Message.ts:253](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L253)
+[Message.ts:237](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L237)
 
 ___
 
@@ -45,17 +55,17 @@ ___
 
 #### Defined in
 
-[Message.ts:255](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L255)
+[Message.ts:239](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L239)
 
 ___
 
 ### conversation
 
- **conversation**: [`Conversation`](../modules.md#conversation)
+ **conversation**: [`Conversation`](../interfaces/Conversation.md)
 
 #### Defined in
 
-[Message.ts:254](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L254)
+[Message.ts:238](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L238)
 
 ___
 
@@ -65,7 +75,7 @@ ___
 
 #### Defined in
 
-[Message.ts:257](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L257)
+[Message.ts:241](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L241)
 
 ___
 
@@ -75,7 +85,7 @@ ___
 
 #### Defined in
 
-[Message.ts:248](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L248)
+[Message.ts:232](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L232)
 
 ___
 
@@ -85,7 +95,7 @@ ___
 
 #### Defined in
 
-[Message.ts:249](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L249)
+[Message.ts:233](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L233)
 
 ___
 
@@ -95,7 +105,7 @@ ___
 
 #### Defined in
 
-[Message.ts:251](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L251)
+[Message.ts:235](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L235)
 
 ___
 
@@ -105,7 +115,7 @@ ___
 
 #### Defined in
 
-[Message.ts:250](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L250)
+[Message.ts:234](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L234)
 
 ___
 
@@ -115,13 +125,48 @@ ___
 
 #### Defined in
 
-[Message.ts:252](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L252)
+[Message.ts:236](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L236)
 
 ## Methods
 
+### toBytes
+
+**toBytes**(): `Uint8Array`
+
+#### Returns
+
+`Uint8Array`
+
+#### Defined in
+
+[Message.ts:270](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L270)
+
+___
+
+### fromBytes
+
+`Static` **fromBytes**(`data`, `client`): `Promise`<[`DecodedMessage`](DecodedMessage.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Uint8Array` |
+| `client` | [`Client`](Client.md) |
+
+#### Returns
+
+`Promise`<[`DecodedMessage`](DecodedMessage.md)\>
+
+#### Defined in
+
+[Message.ts:283](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L283)
+
+___
+
 ### fromV1Message
 
-`Static` **fromV1Message**(`message`, `content`, `contentType`, `contentTopic`, `conversation`, `error?`): [`DecodedMessage`](DecodedMessage.md)
+`Static` **fromV1Message**(`message`, `content`, `contentType`, `contentBytes`, `contentTopic`, `conversation`, `error?`): [`DecodedMessage`](DecodedMessage.md)
 
 #### Parameters
 
@@ -130,8 +175,9 @@ ___
 | `message` | `MessageV1` |
 | `content` | `any` |
 | `contentType` | [`ContentTypeId`](ContentTypeId.md) |
+| `contentBytes` | `Uint8Array` |
 | `contentTopic` | `string` |
-| `conversation` | [`Conversation`](../modules.md#conversation) |
+| `conversation` | [`Conversation`](../interfaces/Conversation.md) |
 | `error?` | `Error` |
 
 #### Returns
@@ -140,13 +186,13 @@ ___
 
 #### Defined in
 
-[Message.ts:283](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L283)
+[Message.ts:318](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L318)
 
 ___
 
 ### fromV2Message
 
-`Static` **fromV2Message**(`message`, `content`, `contentType`, `contentTopic`, `conversation`, `error?`): [`DecodedMessage`](DecodedMessage.md)
+`Static` **fromV2Message**(`message`, `content`, `contentType`, `contentTopic`, `contentBytes`, `conversation`, `senderAddress`, `error?`): [`DecodedMessage`](DecodedMessage.md)
 
 #### Parameters
 
@@ -156,7 +202,9 @@ ___
 | `content` | `any` |
 | `contentType` | [`ContentTypeId`](ContentTypeId.md) |
 | `contentTopic` | `string` |
-| `conversation` | [`Conversation`](../modules.md#conversation) |
+| `contentBytes` | `Uint8Array` |
+| `conversation` | [`Conversation`](../interfaces/Conversation.md) |
+| `senderAddress` | `string` |
 | `error?` | `Error` |
 
 #### Returns
@@ -165,4 +213,4 @@ ___
 
 #### Defined in
 
-[Message.ts:309](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L309)
+[Message.ts:346](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L346)

--- a/docs/client-sdk/javascript/reference/classes/EncryptedPersistence.md
+++ b/docs/client-sdk/javascript/reference/classes/EncryptedPersistence.md
@@ -1,0 +1,196 @@
+<!---->
+# Class: EncryptedPersistence
+
+EncryptedPersistence is a Persistence implementation that uses ECIES to encrypt all values
+ECIES encryption protects against unauthorized reads, but not unauthorized writes.
+A third party with access to the underlying store could write malicious data using the public key of the owner
+
+## Implements
+
+- [`Persistence`](../interfaces/Persistence.md)
+
+## Constructors
+
+### constructor
+
+**new EncryptedPersistence**(`persistence`, `privateKey`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `persistence` | [`Persistence`](../interfaces/Persistence.md) |
+| `privateKey` | `SignedPrivateKey` \| [`PrivateKey`](PrivateKey.md) |
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:20](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L20)
+
+## Properties
+
+### persistence
+
+ `Private` **persistence**: [`Persistence`](../interfaces/Persistence.md)
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:15](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L15)
+
+___
+
+### privateKey
+
+ `Private` **privateKey**: `SignedPrivateKey` \| [`PrivateKey`](PrivateKey.md)
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:16](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L16)
+
+___
+
+### privateKeyBytes
+
+ `Private` **privateKeyBytes**: `Buffer`
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:17](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L17)
+
+___
+
+### publicKey
+
+ `Private` **publicKey**: `Buffer`
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:18](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L18)
+
+## Methods
+
+### decrypt
+
+`Private` **decrypt**(`value`): `Promise`<`Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`Uint8Array`\>
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:48](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L48)
+
+___
+
+### deserializeEcies
+
+`Private` **deserializeEcies**(`data`): `Promise`<`Ecies`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`Ecies`\>
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:60](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L60)
+
+___
+
+### encrypt
+
+`Private` **encrypt**(`value`): `Promise`<`Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`Uint8Array`\>
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:43](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L43)
+
+___
+
+### getItem
+
+**getItem**(`key`): `Promise`<``null`` \| `Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| `Uint8Array`\>
+
+#### Implementation of
+
+[Persistence](../interfaces/Persistence.md).[getItem](../interfaces/Persistence.md#getitem)
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:30](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L30)
+
+___
+
+### serializeEcies
+
+`Private` **serializeEcies**(`data`): `Promise`<`Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Ecies` |
+
+#### Returns
+
+`Promise`<`Uint8Array`\>
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:54](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L54)
+
+___
+
+### setItem
+
+**setItem**(`key`, `value`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+| `value` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Implementation of
+
+[Persistence](../interfaces/Persistence.md).[setItem](../interfaces/Persistence.md#setitem)
+
+#### Defined in
+
+[keystore/persistence/EncryptedPersistence.ts:38](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/EncryptedPersistence.ts#L38)

--- a/docs/client-sdk/javascript/reference/classes/InMemoryKeystore.md
+++ b/docs/client-sdk/javascript/reference/classes/InMemoryKeystore.md
@@ -1,0 +1,406 @@
+<!---->
+# Class: InMemoryKeystore
+
+A Keystore is responsible for holding the user's XMTP private keys and using them to encrypt/decrypt/sign messages.
+Keystores are instantiated using a `KeystoreProvider`
+
+## Implements
+
+- [`Keystore`](../interfaces/Keystore.md)
+
+## Constructors
+
+### constructor
+
+**new InMemoryKeystore**(`keys`, `inviteStore`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `keys` | `PrivateKeyBundleV1` |
+| `inviteStore` | `default` |
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:41](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L41)
+
+## Properties
+
+### accountAddress
+
+ `Private` **accountAddress**: `undefined` \| `string`
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:39](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L39)
+
+___
+
+### authenticator
+
+ `Private` **authenticator**: `default`
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:38](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L38)
+
+___
+
+### inviteStore
+
+ `Private` **inviteStore**: `default`
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:37](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L37)
+
+___
+
+### v1Keys
+
+ `Private` **v1Keys**: `PrivateKeyBundleV1`
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:35](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L35)
+
+___
+
+### v2Keys
+
+ `Private` **v2Keys**: `PrivateKeyBundleV2`
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:36](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L36)
+
+## Methods
+
+### createAuthToken
+
+**createAuthToken**(`«destructured»`): `Promise`<`Token`\>
+
+Create an XMTP auth token to be used as a header on XMTP API requests
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `«destructured»` | `CreateAuthTokenRequest` |
+
+#### Returns
+
+`Promise`<`Token`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[createAuthToken](../interfaces/Keystore.md#createauthtoken)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:153](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L153)
+
+___
+
+### createInvite
+
+**createInvite**(`req`): `Promise`<`CreateInviteResponse`\>
+
+Create a sealed/encrypted invite and store the Topic keys in the Keystore for later use.
+The returned invite payload must be sent to the network for the other party to be able to communicate.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `CreateInviteRequest` |
+
+#### Returns
+
+`Promise`<`CreateInviteResponse`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[createInvite](../interfaces/Keystore.md#createinvite)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:265](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L265)
+
+___
+
+### decryptV1
+
+**decryptV1**(`req`): `Promise`<`DecryptResponse`\>
+
+Decrypt a batch of V1 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `DecryptV1Request` |
+
+#### Returns
+
+`Promise`<`DecryptResponse`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[decryptV1](../interfaces/Keystore.md#decryptv1)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:52](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L52)
+
+___
+
+### decryptV2
+
+**decryptV2**(`req`): `Promise`<`DecryptResponse`\>
+
+Decrypt a batch of V2 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `DecryptV2Request` |
+
+#### Returns
+
+`Promise`<`DecryptResponse`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[decryptV2](../interfaces/Keystore.md#decryptv2)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:83](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L83)
+
+___
+
+### encryptV1
+
+**encryptV1**(`req`): `Promise`<`EncryptResponse`\>
+
+Encrypt a batch of V1 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `EncryptV1Request` |
+
+#### Returns
+
+`Promise`<`EncryptResponse`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[encryptV1](../interfaces/Keystore.md#encryptv1)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:121](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L121)
+
+___
+
+### encryptV2
+
+**encryptV2**(`req`): `Promise`<`EncryptResponse`\>
+
+Encrypt a batch of V2 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `EncryptV2Request` |
+
+#### Returns
+
+`Promise`<`EncryptResponse`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[encryptV2](../interfaces/Keystore.md#encryptv2)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:161](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L161)
+
+___
+
+### getAccountAddress
+
+**getAccountAddress**(): `Promise`<`string`\>
+
+Get the account address of the wallet used to create the Keystore
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[getAccountAddress](../interfaces/Keystore.md#getaccountaddress)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:356](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L356)
+
+___
+
+### getPrivateKeyBundle
+
+**getPrivateKeyBundle**(): `Promise`<`PrivateKeyBundleV1`\>
+
+Export the private keys. May throw an error if the keystore implementation does not allow this operation
+
+#### Returns
+
+`Promise`<`PrivateKeyBundleV1`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[getPrivateKeyBundle](../interfaces/Keystore.md#getprivatekeybundle)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:352](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L352)
+
+___
+
+### getPublicKeyBundle
+
+**getPublicKeyBundle**(): `Promise`<[`PublicKeyBundle`](PublicKeyBundle.md)\>
+
+Get the `PublicKeyBundle` associated with the Keystore's private keys
+
+#### Returns
+
+`Promise`<[`PublicKeyBundle`](PublicKeyBundle.md)\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[getPublicKeyBundle](../interfaces/Keystore.md#getpublickeybundle)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:348](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L348)
+
+___
+
+### getV2Conversations
+
+**getV2Conversations**(): `Promise`<`ConversationReference`[]\>
+
+Get a list of V2 conversations
+
+#### Returns
+
+`Promise`<`ConversationReference`[]\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[getV2Conversations](../interfaces/Keystore.md#getv2conversations)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:335](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L335)
+
+___
+
+### lookupTopic
+
+**lookupTopic**(`topic`): `undefined` \| `WithoutUndefined`<`TopicMap_TopicData`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `topic` | `string` |
+
+#### Returns
+
+`undefined` \| `WithoutUndefined`<`TopicMap_TopicData`\>
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:367](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L367)
+
+___
+
+### saveInvites
+
+**saveInvites**(`req`): `Promise`<`SaveInvitesResponse`\>
+
+Take a batch of invite messages and store the `TopicKeys` for later use in decrypting messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `SaveInvitesRequest` |
+
+#### Returns
+
+`Promise`<`SaveInvitesResponse`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[saveInvites](../interfaces/Keystore.md#saveinvites)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:200](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L200)
+
+___
+
+### signDigest
+
+**signDigest**(`req`): `Promise`<`Signature`\>
+
+Sign the provided digest with either the `IdentityKey` or a specified `PreKey`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `SignDigestRequest` |
+
+#### Returns
+
+`Promise`<`Signature`\>
+
+#### Implementation of
+
+[Keystore](../interfaces/Keystore.md).[signDigest](../interfaces/Keystore.md#signdigest)
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:300](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L300)
+
+___
+
+### create
+
+`Static` **create**(`keys`, `persistence?`): `Promise`<[`InMemoryKeystore`](InMemoryKeystore.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `keys` | `PrivateKeyBundleV1` |
+| `persistence?` | [`Persistence`](../interfaces/Persistence.md) |
+
+#### Returns
+
+`Promise`<[`InMemoryKeystore`](InMemoryKeystore.md)\>
+
+#### Defined in
+
+[keystore/InMemoryKeystore.ts:48](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/InMemoryKeystore.ts#L48)

--- a/docs/client-sdk/javascript/reference/classes/KeyGeneratorKeystoreProvider.md
+++ b/docs/client-sdk/javascript/reference/classes/KeyGeneratorKeystoreProvider.md
@@ -1,0 +1,42 @@
+<!---->
+# Class: KeyGeneratorKeystoreProvider
+
+KeyGeneratorKeystoreProvider will create a new XMTP `PrivateKeyBundle` and persist it to the network
+This provider should always be specified last in the list of `keystoreProviders` on client creation,
+as it will overwrite any XMTP identities already on the network
+
+## Implements
+
+- [`KeystoreProvider`](../interfaces/KeystoreProvider.md)
+
+## Constructors
+
+### constructor
+
+**new KeyGeneratorKeystoreProvider**()
+
+## Methods
+
+### newKeystore
+
+**newKeystore**(`opts`, `apiClient`, `wallet?`): `Promise`<[`Keystore`](../interfaces/Keystore.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts` | `KeystoreProviderOptions` |
+| `apiClient` | `default` |
+| `wallet?` | [`Signer`](../interfaces/Signer.md) |
+
+#### Returns
+
+`Promise`<[`Keystore`](../interfaces/Keystore.md)\>
+
+#### Implementation of
+
+[KeystoreProvider](../interfaces/KeystoreProvider.md).[newKeystore](../interfaces/KeystoreProvider.md#newkeystore)
+
+#### Defined in
+
+[keystore/providers/KeyGeneratorKeystoreProvider.ts:18](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/providers/KeyGeneratorKeystoreProvider.ts#L18)

--- a/docs/client-sdk/javascript/reference/classes/LocalStoragePersistence.md
+++ b/docs/client-sdk/javascript/reference/classes/LocalStoragePersistence.md
@@ -1,0 +1,75 @@
+<!---->
+# Class: LocalStoragePersistence
+
+## Implements
+
+- [`Persistence`](../interfaces/Persistence.md)
+
+## Constructors
+
+### constructor
+
+**new LocalStoragePersistence**()
+
+#### Defined in
+
+[keystore/persistence/LocalStoragePersistence.ts:6](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/LocalStoragePersistence.ts#L6)
+
+## Properties
+
+### storage
+
+ **storage**: `Storage`
+
+#### Defined in
+
+[keystore/persistence/LocalStoragePersistence.ts:5](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/LocalStoragePersistence.ts#L5)
+
+## Methods
+
+### getItem
+
+**getItem**(`key`): `Promise`<``null`` \| `Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| `Uint8Array`\>
+
+#### Implementation of
+
+[Persistence](../interfaces/Persistence.md).[getItem](../interfaces/Persistence.md#getitem)
+
+#### Defined in
+
+[keystore/persistence/LocalStoragePersistence.ts:13](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/LocalStoragePersistence.ts#L13)
+
+___
+
+### setItem
+
+**setItem**(`key`, `value`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+| `value` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Implementation of
+
+[Persistence](../interfaces/Persistence.md).[setItem](../interfaces/Persistence.md#setitem)
+
+#### Defined in
+
+[keystore/persistence/LocalStoragePersistence.ts:21](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/LocalStoragePersistence.ts#L21)

--- a/docs/client-sdk/javascript/reference/classes/NetworkKeystoreProvider.md
+++ b/docs/client-sdk/javascript/reference/classes/NetworkKeystoreProvider.md
@@ -1,0 +1,42 @@
+<!---->
+# Class: NetworkKeystoreProvider
+
+NetworkKeystoreProvider will look on the XMTP network for an `EncryptedPrivateKeyBundle`
+on the user's private storage topic. If found, will decrypt the bundle using a wallet
+signature and instantiate a Keystore instance using the decrypted value.
+
+## Implements
+
+- [`KeystoreProvider`](../interfaces/KeystoreProvider.md)
+
+## Constructors
+
+### constructor
+
+**new NetworkKeystoreProvider**()
+
+## Methods
+
+### newKeystore
+
+**newKeystore**(`opts`, `apiClient`, `wallet?`): `Promise`<[`Keystore`](../interfaces/Keystore.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts` | `KeystoreProviderOptions` |
+| `apiClient` | `default` |
+| `wallet?` | [`Signer`](../interfaces/Signer.md) |
+
+#### Returns
+
+`Promise`<[`Keystore`](../interfaces/Keystore.md)\>
+
+#### Implementation of
+
+[KeystoreProvider](../interfaces/KeystoreProvider.md).[newKeystore](../interfaces/KeystoreProvider.md#newkeystore)
+
+#### Defined in
+
+[keystore/providers/NetworkKeystoreProvider.ts:17](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/providers/NetworkKeystoreProvider.ts#L17)

--- a/docs/client-sdk/javascript/reference/classes/PrefixedPersistence.md
+++ b/docs/client-sdk/javascript/reference/classes/PrefixedPersistence.md
@@ -1,0 +1,100 @@
+<!---->
+# Class: PrefixedPersistence
+
+## Constructors
+
+### constructor
+
+**new PrefixedPersistence**(`prefix`, `persistence`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `prefix` | `string` |
+| `persistence` | [`Persistence`](../interfaces/Persistence.md) |
+
+#### Defined in
+
+[keystore/persistence/PrefixedPersistence.ts:7](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/PrefixedPersistence.ts#L7)
+
+## Properties
+
+### persistence
+
+ **persistence**: [`Persistence`](../interfaces/Persistence.md)
+
+#### Defined in
+
+[keystore/persistence/PrefixedPersistence.ts:5](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/PrefixedPersistence.ts#L5)
+
+___
+
+### prefix
+
+ **prefix**: `string`
+
+#### Defined in
+
+[keystore/persistence/PrefixedPersistence.ts:4](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/PrefixedPersistence.ts#L4)
+
+## Methods
+
+### buildKey
+
+`Private` **buildKey**(`key`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[keystore/persistence/PrefixedPersistence.ts:20](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/PrefixedPersistence.ts#L20)
+
+___
+
+### getItem
+
+**getItem**(`key`): `Promise`<``null`` \| `Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| `Uint8Array`\>
+
+#### Defined in
+
+[keystore/persistence/PrefixedPersistence.ts:12](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/PrefixedPersistence.ts#L12)
+
+___
+
+### setItem
+
+**setItem**(`key`, `value`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+| `value` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[keystore/persistence/PrefixedPersistence.ts:16](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/PrefixedPersistence.ts#L16)

--- a/docs/client-sdk/javascript/reference/classes/PrivateKey.md
+++ b/docs/client-sdk/javascript/reference/classes/PrivateKey.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[crypto/PrivateKey.ts:181](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L181)
+[crypto/PrivateKey.ts:312](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L312)
 
 ## Properties
 
@@ -33,7 +33,7 @@ privateKey.PrivateKey.publicKey
 
 #### Defined in
 
-[crypto/PrivateKey.ts:179](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L179)
+[crypto/PrivateKey.ts:310](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L310)
 
 ___
 
@@ -47,7 +47,7 @@ privateKey.PrivateKey.secp256k1
 
 #### Defined in
 
-[crypto/PrivateKey.ts:178](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L178)
+[crypto/PrivateKey.ts:309](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L309)
 
 ___
 
@@ -61,7 +61,7 @@ privateKey.PrivateKey.timestamp
 
 #### Defined in
 
-[crypto/PrivateKey.ts:177](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L177)
+[crypto/PrivateKey.ts:308](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L308)
 
 ## Methods
 
@@ -73,7 +73,7 @@ privateKey.PrivateKey.timestamp
 
 | Name | Type |
 | :------ | :------ |
-| `encrypted` | `default` |
+| `encrypted` | [`Ciphertext`](Ciphertext.md) |
 | `peer` | [`PublicKey`](PublicKey.md) |
 | `additionalData?` | `Uint8Array` |
 
@@ -83,13 +83,13 @@ privateKey.PrivateKey.timestamp
 
 #### Defined in
 
-[crypto/PrivateKey.ts:262](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L262)
+[crypto/PrivateKey.ts:393](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L393)
 
 ___
 
 ### encrypt
 
-**encrypt**(`plain`, `peer`, `additionalData?`): `Promise`<`default`\>
+**encrypt**(`plain`, `peer`, `additionalData?`): `Promise`<[`Ciphertext`](Ciphertext.md)\>
 
 #### Parameters
 
@@ -101,11 +101,11 @@ ___
 
 #### Returns
 
-`Promise`<`default`\>
+`Promise`<[`Ciphertext`](Ciphertext.md)\>
 
 #### Defined in
 
-[crypto/PrivateKey.ts:251](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L251)
+[crypto/PrivateKey.ts:382](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L382)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:212](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L212)
+[crypto/PrivateKey.ts:343](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L343)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:272](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L272)
+[crypto/PrivateKey.ts:403](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L403)
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `peer` | `SignedPublicKey` \| [`PublicKey`](PublicKey.md) |
+| `peer` | [`SignedPublicKey`](SignedPublicKey.md) \| [`PublicKey`](PublicKey.md) |
 
 #### Returns
 
@@ -159,13 +159,13 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:240](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L240)
+[crypto/PrivateKey.ts:371](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L371)
 
 ___
 
 ### sign
 
-**sign**(`digest`): `Promise`<`default`\>
+**sign**(`digest`): `Promise`<[`Signature`](Signature.md)\>
 
 #### Parameters
 
@@ -175,11 +175,11 @@ ___
 
 #### Returns
 
-`Promise`<`default`\>
+`Promise`<[`Signature`](Signature.md)\>
 
 #### Defined in
 
-[crypto/PrivateKey.ts:217](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L217)
+[crypto/PrivateKey.ts:348](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L348)
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:232](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L232)
+[crypto/PrivateKey.ts:363](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L363)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:277](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L277)
+[crypto/PrivateKey.ts:408](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L408)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:282](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L282)
+[crypto/PrivateKey.ts:413](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L413)
 
 ___
 
@@ -247,4 +247,4 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKey.ts:195](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKey.ts#L195)
+[crypto/PrivateKey.ts:326](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKey.ts#L326)

--- a/docs/client-sdk/javascript/reference/classes/PublicKeyBundle.md
+++ b/docs/client-sdk/javascript/reference/classes/PublicKeyBundle.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:59](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L59)
+[crypto/PublicKeyBundle.ts:100](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L100)
 
 ## Properties
 
@@ -33,7 +33,7 @@ publicKey.PublicKeyBundle.identityKey
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:56](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L56)
+[crypto/PublicKeyBundle.ts:97](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L97)
 
 ___
 
@@ -47,7 +47,7 @@ publicKey.PublicKeyBundle.preKey
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:57](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L57)
+[crypto/PublicKeyBundle.ts:98](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L98)
 
 ## Methods
 
@@ -67,7 +67,7 @@ publicKey.PublicKeyBundle.preKey
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:70](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L70)
+[crypto/PublicKeyBundle.ts:111](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L111)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:81](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L81)
+[crypto/PublicKeyBundle.ts:122](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L122)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:77](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L77)
+[crypto/PublicKeyBundle.ts:118](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L118)
 
 ___
 
@@ -115,4 +115,4 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:85](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L85)
+[crypto/PublicKeyBundle.ts:126](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L126)

--- a/docs/client-sdk/javascript/reference/classes/Signature.md
+++ b/docs/client-sdk/javascript/reference/classes/Signature.md
@@ -1,0 +1,144 @@
+<!---->
+# Class: Signature
+
+## Implements
+
+- `Signature`
+
+## Constructors
+
+### constructor
+
+**new Signature**(`obj`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `obj` | `Partial`<`Signature`\> |
+
+#### Defined in
+
+[crypto/Signature.ts:65](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L65)
+
+## Properties
+
+### ecdsaCompact
+
+ **ecdsaCompact**: `undefined` \| `ECDSACompactWithRecovery`
+
+#### Implementation of
+
+signature.Signature.ecdsaCompact
+
+#### Defined in
+
+[crypto/Signature.ts:61](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L61)
+
+___
+
+### walletEcdsaCompact
+
+ **walletEcdsaCompact**: `undefined` \| `ECDSACompactWithRecovery`
+
+#### Implementation of
+
+signature.Signature.walletEcdsaCompact
+
+#### Defined in
+
+[crypto/Signature.ts:63](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L63)
+
+## Methods
+
+### equals
+
+**equals**(`other`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `other` | [`Signature`](Signature.md) |
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[crypto/Signature.ts:110](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L110)
+
+___
+
+### getPublicKey
+
+**getPublicKey**(`digest`): `undefined` \| [`PublicKey`](PublicKey.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `digest` | `Uint8Array` |
+
+#### Returns
+
+`undefined` \| [`PublicKey`](PublicKey.md)
+
+#### Defined in
+
+[crypto/Signature.ts:92](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L92)
+
+___
+
+### signerKey
+
+**signerKey**(`key`): `Promise`<`undefined` \| `UnsignedPublicKey`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | [`SignedPublicKey`](SignedPublicKey.md) |
+
+#### Returns
+
+`Promise`<`undefined` \| `UnsignedPublicKey`\>
+
+#### Defined in
+
+[crypto/Signature.ts:78](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L78)
+
+___
+
+### toBytes
+
+**toBytes**(): `Uint8Array`
+
+#### Returns
+
+`Uint8Array`
+
+#### Defined in
+
+[crypto/Signature.ts:120](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L120)
+
+___
+
+### fromBytes
+
+`Static` **fromBytes**(`bytes`): [`Signature`](Signature.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `bytes` | `Uint8Array` |
+
+#### Returns
+
+[`Signature`](Signature.md)
+
+#### Defined in
+
+[crypto/Signature.ts:124](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/Signature.ts#L124)

--- a/docs/client-sdk/javascript/reference/classes/SignedPublicKey.md
+++ b/docs/client-sdk/javascript/reference/classes/SignedPublicKey.md
@@ -1,27 +1,27 @@
 <!---->
-# Class: PublicKey
+# Class: SignedPublicKey
 
 ## Hierarchy
 
 - `UnsignedPublicKey`
 
-  ↳ **`PublicKey`**
+  ↳ **`SignedPublicKey`**
 
 ## Implements
 
-- `PublicKey`
+- `SignedPublicKey`
 
 ## Constructors
 
 ### constructor
 
-**new PublicKey**(`obj`)
+**new SignedPublicKey**(`obj`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `obj` | `PublicKey` |
+| `obj` | `SignedPublicKey` |
 
 #### Overrides
 
@@ -29,7 +29,7 @@ UnsignedPublicKey.constructor
 
 #### Defined in
 
-[crypto/PublicKey.ts:423](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L423)
+[crypto/PublicKey.ts:125](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L125)
 
 ## Properties
 
@@ -47,13 +47,23 @@ UnsignedPublicKey.createdNs
 
 ___
 
-### secp256k1Uncompressed
+### keyBytes
 
- **secp256k1Uncompressed**: `secp256k1Uncompressed`
+ **keyBytes**: `Uint8Array`
 
 #### Implementation of
 
-publicKey.PublicKey.secp256k1Uncompressed
+publicKey.SignedPublicKey.keyBytes
+
+#### Defined in
+
+[crypto/PublicKey.ts:122](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L122)
+
+___
+
+### secp256k1Uncompressed
+
+ **secp256k1Uncompressed**: `secp256k1Uncompressed`
 
 #### Inherited from
 
@@ -67,15 +77,15 @@ ___
 
 ### signature
 
- `Optional` **signature**: [`Signature`](Signature.md)
+ **signature**: [`Signature`](Signature.md)
 
 #### Implementation of
 
-publicKey.PublicKey.signature
+publicKey.SignedPublicKey.signature
 
 #### Defined in
 
-[crypto/PublicKey.ts:421](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L421)
+[crypto/PublicKey.ts:123](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L123)
 
 ## Accessors
 
@@ -87,17 +97,27 @@ publicKey.PublicKey.signature
 
 `Long`
 
-#### Implementation of
-
-publicKey.PublicKey.timestamp
-
-#### Overrides
+#### Inherited from
 
 UnsignedPublicKey.timestamp
 
 #### Defined in
 
-[crypto/PublicKey.ts:433](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L433)
+[crypto/PublicKey.ts:66](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L66)
+
+___
+
+### unsignedKey
+
+`get` **unsignedKey**(): `UnsignedPublicKey`
+
+#### Returns
+
+`UnsignedPublicKey`
+
+#### Defined in
+
+[crypto/PublicKey.ts:138](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L138)
 
 ## Methods
 
@@ -111,7 +131,7 @@ UnsignedPublicKey.timestamp
 
 #### Defined in
 
-[crypto/PublicKey.ts:437](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L437)
+[crypto/PublicKey.ts:173](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L173)
 
 ___
 
@@ -123,19 +143,19 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `other` | [`PublicKey`](PublicKey.md) |
+| `other` | [`SignedPublicKey`](SignedPublicKey.md) |
 
 #### Returns
 
 `boolean`
 
-#### Inherited from
+#### Overrides
 
 UnsignedPublicKey.equals
 
 #### Defined in
 
-[crypto/PublicKey.ts:94](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L94)
+[crypto/PublicKey.ts:165](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L165)
 
 ___
 
@@ -193,23 +213,17 @@ UnsignedPublicKey.isFromLegacyKey
 
 ___
 
-### signWithWallet
+### signerKey
 
-**signWithWallet**(`wallet`): `Promise`<`void`\>
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `wallet` | [`Signer`](../interfaces/Signer.md) |
+**signerKey**(): `Promise`<`undefined` \| `UnsignedPublicKey`\>
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`<`undefined` \| `UnsignedPublicKey`\>
 
 #### Defined in
 
-[crypto/PublicKey.ts:445](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L445)
+[crypto/PublicKey.ts:146](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L146)
 
 ___
 
@@ -227,7 +241,21 @@ UnsignedPublicKey.toBytes
 
 #### Defined in
 
-[crypto/PublicKey.ts:480](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L480)
+[crypto/PublicKey.ts:178](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L178)
+
+___
+
+### toLegacyKey
+
+**toLegacyKey**(): [`PublicKey`](PublicKey.md)
+
+#### Returns
+
+[`PublicKey`](PublicKey.md)
+
+#### Defined in
+
+[crypto/PublicKey.ts:187](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L187)
 
 ___
 
@@ -282,21 +310,21 @@ ___
 
 ### walletSignatureAddress
 
-**walletSignatureAddress**(): `string`
+**walletSignatureAddress**(): `Promise`<`string`\>
 
 #### Returns
 
-`string`
+`Promise`<`string`\>
 
 #### Defined in
 
-[crypto/PublicKey.ts:466](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L466)
+[crypto/PublicKey.ts:153](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L153)
 
 ___
 
 ### fromBytes
 
-`Static` **fromBytes**(`bytes`): [`PublicKey`](PublicKey.md)
+`Static` **fromBytes**(`bytes`): [`SignedPublicKey`](SignedPublicKey.md)
 
 #### Parameters
 
@@ -306,7 +334,7 @@ ___
 
 #### Returns
 
-[`PublicKey`](PublicKey.md)
+[`SignedPublicKey`](SignedPublicKey.md)
 
 #### Overrides
 
@@ -314,4 +342,25 @@ UnsignedPublicKey.fromBytes
 
 #### Defined in
 
-[crypto/PublicKey.ts:484](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L484)
+[crypto/PublicKey.ts:183](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L183)
+
+___
+
+### fromLegacyKey
+
+`Static` **fromLegacyKey**(`legacyKey`, `signedByWallet?`): [`SignedPublicKey`](SignedPublicKey.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `legacyKey` | [`PublicKey`](PublicKey.md) |
+| `signedByWallet?` | `boolean` |
+
+#### Returns
+
+[`SignedPublicKey`](SignedPublicKey.md)
+
+#### Defined in
+
+[crypto/PublicKey.ts:204](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKey.ts#L204)

--- a/docs/client-sdk/javascript/reference/classes/SignedPublicKeyBundle.md
+++ b/docs/client-sdk/javascript/reference/classes/SignedPublicKeyBundle.md
@@ -19,13 +19,13 @@
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:11](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L11)
+[crypto/PublicKeyBundle.ts:41](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L41)
 
 ## Properties
 
 ### identityKey
 
- **identityKey**: `SignedPublicKey`
+ **identityKey**: [`SignedPublicKey`](SignedPublicKey.md)
 
 #### Implementation of
 
@@ -33,13 +33,13 @@ publicKey.SignedPublicKeyBundle.identityKey
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:8](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L8)
+[crypto/PublicKeyBundle.ts:38](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L38)
 
 ___
 
 ### preKey
 
- **preKey**: `SignedPublicKey`
+ **preKey**: [`SignedPublicKey`](SignedPublicKey.md)
 
 #### Implementation of
 
@@ -47,7 +47,7 @@ publicKey.SignedPublicKeyBundle.preKey
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:9](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L9)
+[crypto/PublicKeyBundle.ts:39](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L39)
 
 ## Methods
 
@@ -67,7 +67,21 @@ publicKey.SignedPublicKeyBundle.preKey
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:26](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L26)
+[crypto/PublicKeyBundle.ts:56](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L56)
+
+___
+
+### isFromLegacyBundle
+
+**isFromLegacyBundle**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[crypto/PublicKeyBundle.ts:67](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L67)
 
 ___
 
@@ -81,7 +95,21 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:33](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L33)
+[crypto/PublicKeyBundle.ts:63](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L63)
+
+___
+
+### toLegacyBundle
+
+**toLegacyBundle**(): [`PublicKeyBundle`](PublicKeyBundle.md)
+
+#### Returns
+
+[`PublicKeyBundle`](PublicKeyBundle.md)
+
+#### Defined in
+
+[crypto/PublicKeyBundle.ts:71](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L71)
 
 ___
 
@@ -95,7 +123,7 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:22](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L22)
+[crypto/PublicKeyBundle.ts:52](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L52)
 
 ___
 
@@ -115,7 +143,7 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:37](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L37)
+[crypto/PublicKeyBundle.ts:78](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L78)
 
 ___
 
@@ -135,4 +163,4 @@ ___
 
 #### Defined in
 
-[crypto/PublicKeyBundle.ts:42](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PublicKeyBundle.ts#L42)
+[crypto/PublicKeyBundle.ts:83](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PublicKeyBundle.ts#L83)

--- a/docs/client-sdk/javascript/reference/classes/StaticKeystoreProvider.md
+++ b/docs/client-sdk/javascript/reference/classes/StaticKeystoreProvider.md
@@ -1,0 +1,42 @@
+<!---->
+# Class: StaticKeystoreProvider
+
+StaticKeystoreProvider will look for a `privateKeyOverride` in the provided options,
+and bootstrap a Keystore using those options if provided.
+
+If no `privateKeyOverride` is supplied will throw a `KeystoreProviderUnavailableError` causing
+the client to continue iterating through the `KeystoreProviders` list.
+
+## Implements
+
+- [`KeystoreProvider`](../interfaces/KeystoreProvider.md)
+
+## Constructors
+
+### constructor
+
+**new StaticKeystoreProvider**()
+
+## Methods
+
+### newKeystore
+
+**newKeystore**(`opts`): `Promise`<[`Keystore`](../interfaces/Keystore.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts` | `KeystoreProviderOptions` |
+
+#### Returns
+
+`Promise`<[`Keystore`](../interfaces/Keystore.md)\>
+
+#### Implementation of
+
+[KeystoreProvider](../interfaces/KeystoreProvider.md).[newKeystore](../interfaces/KeystoreProvider.md#newkeystore)
+
+#### Defined in
+
+[keystore/providers/StaticKeystoreProvider.ts:19](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/providers/StaticKeystoreProvider.ts#L19)

--- a/docs/client-sdk/javascript/reference/classes/Stream.md
+++ b/docs/client-sdk/javascript/reference/classes/Stream.md
@@ -33,7 +33,7 @@ As such can be used with constructs like for-await-of, yield*, array destructing
 
 #### Defined in
 
-[Stream.ts:28](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L28)
+[Stream.ts:28](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L28)
 
 ## Properties
 
@@ -43,7 +43,7 @@ As such can be used with constructs like for-await-of, yield*, array destructing
 
 #### Defined in
 
-[Stream.ts:24](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L24)
+[Stream.ts:24](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L24)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:17](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L17)
+[Stream.ts:17](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L17)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:19](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L19)
+[Stream.ts:19](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L19)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:21](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L21)
+[Stream.ts:21](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L21)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:16](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L16)
+[Stream.ts:16](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L16)
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:26](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L26)
+[Stream.ts:26](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L26)
 
 ## Methods
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:106](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L106)
+[Stream.ts:106](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L106)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:42](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L42)
+[Stream.ts:42](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L42)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:131](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L131)
+[Stream.ts:131](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L131)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:146](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L146)
+[Stream.ts:146](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L146)
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:114](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L114)
+[Stream.ts:114](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L114)
 
 ___
 
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[Stream.ts:78](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L78)
+[Stream.ts:78](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L78)
 
 ___
 
@@ -231,4 +231,4 @@ ___
 
 #### Defined in
 
-[Stream.ts:94](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Stream.ts#L94)
+[Stream.ts:94](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Stream.ts#L94)

--- a/docs/client-sdk/javascript/reference/classes/TypingNotificationCodec.md
+++ b/docs/client-sdk/javascript/reference/classes/TypingNotificationCodec.md
@@ -1,15 +1,15 @@
 <!---->
-# Class: TextCodec
+# Class: TypingNotificationCodec
 
 ## Implements
 
-- [`ContentCodec`](../interfaces/ContentCodec.md)<`string`\>
+- [`ContentCodec`](../interfaces/ContentCodec.md)<[`TypingNotification`](../modules.md#typingnotification)\>
 
 ## Constructors
 
 ### constructor
 
-**new TextCodec**()
+**new TypingNotificationCodec**()
 
 ## Accessors
 
@@ -27,13 +27,13 @@
 
 #### Defined in
 
-[codecs/Text.ts:18](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Text.ts#L18)
+[codecs/TypingNotification.ts:23](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/TypingNotification.ts#L23)
 
 ## Methods
 
 ### decode
 
-**decode**(`content`): `string`
+**decode**(`content`): [`TypingNotification`](../modules.md#typingnotification)
 
 #### Parameters
 
@@ -43,7 +43,7 @@
 
 #### Returns
 
-`string`
+[`TypingNotification`](../modules.md#typingnotification)
 
 #### Implementation of
 
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[codecs/Text.ts:30](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Text.ts#L30)
+[codecs/TypingNotification.ts:39](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/TypingNotification.ts#L39)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `content` | `string` |
+| `content` | [`TypingNotification`](../modules.md#typingnotification) |
 
 #### Returns
 
@@ -75,4 +75,4 @@ ___
 
 #### Defined in
 
-[codecs/Text.ts:22](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Text.ts#L22)
+[codecs/TypingNotification.ts:27](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/TypingNotification.ts#L27)

--- a/docs/client-sdk/javascript/reference/classes/_category_.json
+++ b/docs/client-sdk/javascript/reference/classes/_category_.json
@@ -1,5 +1,5 @@
 {
- "label": "Classes",
- "position": 1,
- "collapsible": false,
+    "label": "Classes",
+    "position": 1,
+    "collapsible": false,
 }

--- a/docs/client-sdk/javascript/reference/interfaces/ContentCodec.md
+++ b/docs/client-sdk/javascript/reference/interfaces/ContentCodec.md
@@ -11,6 +11,7 @@
 
 - [`CompositeCodec`](../classes/CompositeCodec.md)
 - [`TextCodec`](../classes/TextCodec.md)
+- [`TypingNotificationCodec`](../classes/TypingNotificationCodec.md)
 
 ## Properties
 
@@ -20,7 +21,7 @@
 
 #### Defined in
 
-[MessageContent.ts:45](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L45)
+[MessageContent.ts:45](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L45)
 
 ## Methods
 
@@ -41,7 +42,7 @@
 
 #### Defined in
 
-[MessageContent.ts:47](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L47)
+[MessageContent.ts:47](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L47)
 
 ___
 
@@ -62,4 +63,4 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:46](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L46)
+[MessageContent.ts:46](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L46)

--- a/docs/client-sdk/javascript/reference/interfaces/Conversation.md
+++ b/docs/client-sdk/javascript/reference/interfaces/Conversation.md
@@ -1,0 +1,257 @@
+<!---->
+# Interface: Conversation
+
+Conversation represents either a V1 or V2 conversation with a common set of methods.
+
+## Properties
+
+### clientAddress
+
+ **clientAddress**: `string`
+
+The wallet address connected to the client
+
+#### Defined in
+
+[conversations/Conversation.ts:44](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L44)
+
+___
+
+### context
+
+ `Optional` **context**: `InvitationContext`
+
+Optional field containing the `conversationId` and `metadata` for V2 conversations.
+Will always be undefined on V1 conversations
+
+#### Defined in
+
+[conversations/Conversation.ts:65](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L65)
+
+___
+
+### createdAt
+
+ **createdAt**: `Date`
+
+Timestamp the conversation was created at
+
+#### Defined in
+
+[conversations/Conversation.ts:60](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L60)
+
+___
+
+### ephemeralTopic
+
+ **ephemeralTopic**: `string`
+
+A unique identifier for ephemeral envelopes for a conversation.
+
+#### Defined in
+
+[conversations/Conversation.ts:52](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L52)
+
+___
+
+### peerAddress
+
+ **peerAddress**: `string`
+
+The wallet address of the other party in the conversation
+
+#### Defined in
+
+[conversations/Conversation.ts:56](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L56)
+
+___
+
+### topic
+
+ **topic**: `string`
+
+A unique identifier for a conversation. Each conversation is stored on the network on one topic
+
+#### Defined in
+
+[conversations/Conversation.ts:48](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L48)
+
+## Methods
+
+### decodeMessage
+
+**decodeMessage**(`env`): `Promise`<[`DecodedMessage`](../classes/DecodedMessage.md)\>
+
+Takes a XMTP envelope as input and will decrypt and decode it
+returning a `DecodedMessage` instance.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `env` | `Envelope` |
+
+#### Returns
+
+`Promise`<[`DecodedMessage`](../classes/DecodedMessage.md)\>
+
+#### Defined in
+
+[conversations/Conversation.ts:91](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L91)
+
+___
+
+### messages
+
+**messages**(`opts?`): `Promise`<[`DecodedMessage`](../classes/DecodedMessage.md)[]\>
+
+Retrieve messages in this conversation. Default to returning all messages.
+
+If only a subset is required, results can be narrowed by specifying a start/end
+timestamp.
+
+```ts
+// Get all messages in the past 24 hours
+const messages = await conversation.messages({
+   startTime: new Date(+new Date() - 86_400)
+})
+```
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts?` | [`ListMessagesOptions`](../modules.md#listmessagesoptions) |
+
+#### Returns
+
+`Promise`<[`DecodedMessage`](../classes/DecodedMessage.md)[]\>
+
+#### Defined in
+
+[conversations/Conversation.ts:80](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L80)
+
+___
+
+### messagesPaginated
+
+**messagesPaginated**(`opts?`): `AsyncGenerator`<[`DecodedMessage`](../classes/DecodedMessage.md)[], `any`, `unknown`\>
+
+**`Deprecated`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts?` | `ListMessagesPaginatedOptions` |
+
+#### Returns
+
+`AsyncGenerator`<[`DecodedMessage`](../classes/DecodedMessage.md)[], `any`, `unknown`\>
+
+#### Defined in
+
+[conversations/Conversation.ts:84](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L84)
+
+___
+
+### prepareMessage
+
+**prepareMessage**(`content`, `options?`): `Promise`<`PreparedMessage`\>
+
+Return a `PreparedMessage` that has contains the message ID
+of the message that will be sent.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `content` | `any` |
+| `options?` | [`SendOptions`](../modules.md#sendoptions) |
+
+#### Returns
+
+`Promise`<`PreparedMessage`\>
+
+#### Defined in
+
+[conversations/Conversation.ts:122](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L122)
+
+___
+
+### send
+
+**send**(`content`, `options?`): `Promise`<[`DecodedMessage`](../classes/DecodedMessage.md)\>
+
+Send a message into the conversation
+
+## Example
+```ts
+await conversation.send('Hello world') // returns a `DecodedMessage` instance
+```
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `content` | `any` |
+| `options?` | [`SendOptions`](../modules.md#sendoptions) |
+
+#### Returns
+
+`Promise`<[`DecodedMessage`](../classes/DecodedMessage.md)\>
+
+#### Defined in
+
+[conversations/Conversation.ts:113](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L113)
+
+___
+
+### streamEphemeral
+
+**streamEphemeral**(): `Promise`<[`Stream`](../classes/Stream.md)<[`DecodedMessage`](../classes/DecodedMessage.md)\>\>
+
+Return a `Stream` of new ephemeral messages from this conversation's
+ephemeral topic.
+
+Stream instances are async generators and can be used in
+`for await` statements.
+
+```ts
+for await (const message of await conversation.streamEphemeral()) {
+   console.log(message.content)
+}
+```
+
+#### Returns
+
+`Promise`<[`Stream`](../classes/Stream.md)<[`DecodedMessage`](../classes/DecodedMessage.md)\>\>
+
+#### Defined in
+
+[conversations/Conversation.ts:140](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L140)
+
+___
+
+### streamMessages
+
+**streamMessages**(): `Promise`<[`Stream`](../classes/Stream.md)<[`DecodedMessage`](../classes/DecodedMessage.md)\>\>
+
+Return a `Stream` of new messages in this conversation.
+
+Stream instances are async generators and can be used in
+`for await` statements.
+
+```ts
+for await (const message of await conversation.stream()) {
+   console.log(message.content)
+}
+```
+
+#### Returns
+
+`Promise`<[`Stream`](../classes/Stream.md)<[`DecodedMessage`](../classes/DecodedMessage.md)\>\>
+
+#### Defined in
+
+[conversations/Conversation.ts:104](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/conversations/Conversation.ts#L104)

--- a/docs/client-sdk/javascript/reference/interfaces/EncodedContent.md
+++ b/docs/client-sdk/javascript/reference/interfaces/EncodedContent.md
@@ -9,7 +9,7 @@
 
 #### Defined in
 
-[MessageContent.ts:31](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L31)
+[MessageContent.ts:31](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L31)
 
 ___
 
@@ -19,7 +19,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:32](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L32)
+[MessageContent.ts:32](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L32)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:30](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L30)
+[MessageContent.ts:30](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L30)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:29](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L29)
+[MessageContent.ts:29](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L29)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:28](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L28)
+[MessageContent.ts:28](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L28)

--- a/docs/client-sdk/javascript/reference/interfaces/Keystore.md
+++ b/docs/client-sdk/javascript/reference/interfaces/Keystore.md
@@ -1,0 +1,250 @@
+<!---->
+# Interface: Keystore
+
+A Keystore is responsible for holding the user's XMTP private keys and using them to encrypt/decrypt/sign messages.
+Keystores are instantiated using a `KeystoreProvider`
+
+## Implemented by
+
+- [`InMemoryKeystore`](../classes/InMemoryKeystore.md)
+
+## Methods
+
+### createAuthToken
+
+**createAuthToken**(`req`): `Promise`<`Token`\>
+
+Create an XMTP auth token to be used as a header on XMTP API requests
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `CreateAuthTokenRequest` |
+
+#### Returns
+
+`Promise`<`Token`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:48](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L48)
+
+___
+
+### createInvite
+
+**createInvite**(`req`): `Promise`<`CreateInviteResponse`\>
+
+Create a sealed/encrypted invite and store the Topic keys in the Keystore for later use.
+The returned invite payload must be sent to the network for the other party to be able to communicate.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `CreateInviteRequest` |
+
+#### Returns
+
+`Promise`<`CreateInviteResponse`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:42](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L42)
+
+___
+
+### decryptV1
+
+**decryptV1**(`req`): `Promise`<`DecryptResponse`\>
+
+Decrypt a batch of V1 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `DecryptV1Request` |
+
+#### Returns
+
+`Promise`<`DecryptResponse`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:19](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L19)
+
+___
+
+### decryptV2
+
+**decryptV2**(`req`): `Promise`<`DecryptResponse`\>
+
+Decrypt a batch of V2 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `DecryptV2Request` |
+
+#### Returns
+
+`Promise`<`DecryptResponse`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:23](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L23)
+
+___
+
+### encryptV1
+
+**encryptV1**(`req`): `Promise`<`EncryptResponse`\>
+
+Encrypt a batch of V1 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `EncryptV1Request` |
+
+#### Returns
+
+`Promise`<`EncryptResponse`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:27](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L27)
+
+___
+
+### encryptV2
+
+**encryptV2**(`req`): `Promise`<`EncryptResponse`\>
+
+Encrypt a batch of V2 messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `EncryptV2Request` |
+
+#### Returns
+
+`Promise`<`EncryptResponse`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:31](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L31)
+
+___
+
+### getAccountAddress
+
+**getAccountAddress**(): `Promise`<`string`\>
+
+Get the account address of the wallet used to create the Keystore
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:68](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L68)
+
+___
+
+### getPrivateKeyBundle
+
+**getPrivateKeyBundle**(): `Promise`<`PrivateKeyBundleV1`\>
+
+Export the private keys. May throw an error if the keystore implementation does not allow this operation
+
+#### Returns
+
+`Promise`<`PrivateKeyBundleV1`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:64](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L64)
+
+___
+
+### getPublicKeyBundle
+
+**getPublicKeyBundle**(): `Promise`<`PublicKeyBundle`\>
+
+Get the `PublicKeyBundle` associated with the Keystore's private keys
+
+#### Returns
+
+`Promise`<`PublicKeyBundle`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:60](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L60)
+
+___
+
+### getV2Conversations
+
+**getV2Conversations**(): `Promise`<`ConversationReference`[]\>
+
+Get a list of V2 conversations
+
+#### Returns
+
+`Promise`<`ConversationReference`[]\>
+
+#### Defined in
+
+[keystore/interfaces.ts:56](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L56)
+
+___
+
+### saveInvites
+
+**saveInvites**(`req`): `Promise`<`SaveInvitesResponse`\>
+
+Take a batch of invite messages and store the `TopicKeys` for later use in decrypting messages
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `SaveInvitesRequest` |
+
+#### Returns
+
+`Promise`<`SaveInvitesResponse`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:35](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L35)
+
+___
+
+### signDigest
+
+**signDigest**(`req`): `Promise`<`Signature`\>
+
+Sign the provided digest with either the `IdentityKey` or a specified `PreKey`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | `SignDigestRequest` |
+
+#### Returns
+
+`Promise`<`Signature`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:52](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L52)

--- a/docs/client-sdk/javascript/reference/interfaces/KeystoreProvider.md
+++ b/docs/client-sdk/javascript/reference/interfaces/KeystoreProvider.md
@@ -1,0 +1,33 @@
+<!---->
+# Interface: KeystoreProvider
+
+A Keystore Provider is responsible for either creating a Keystore instance or throwing a KeystoreUnavailableError
+It is typically used once on application startup to bootstrap the Keystore and load/decrypt the user's private keys
+
+## Implemented by
+
+- [`KeyGeneratorKeystoreProvider`](../classes/KeyGeneratorKeystoreProvider.md)
+- [`NetworkKeystoreProvider`](../classes/NetworkKeystoreProvider.md)
+- [`StaticKeystoreProvider`](../classes/StaticKeystoreProvider.md)
+
+## Methods
+
+### newKeystore
+
+**newKeystore**(`opts`, `apiClient`, `wallet?`): `Promise`<[`Keystore`](Keystore.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opts` | `KeystoreProviderOptions` |
+| `apiClient` | `default` |
+| `wallet?` | [`Signer`](Signer.md) |
+
+#### Returns
+
+`Promise`<[`Keystore`](Keystore.md)\>
+
+#### Defined in
+
+[keystore/providers/interfaces.ts:17](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/providers/interfaces.ts#L17)

--- a/docs/client-sdk/javascript/reference/interfaces/Persistence.md
+++ b/docs/client-sdk/javascript/reference/interfaces/Persistence.md
@@ -1,0 +1,48 @@
+<!---->
+# Interface: Persistence
+
+## Implemented by
+
+- [`EncryptedPersistence`](../classes/EncryptedPersistence.md)
+- [`LocalStoragePersistence`](../classes/LocalStoragePersistence.md)
+
+## Methods
+
+### getItem
+
+**getItem**(`key`): `Promise`<``null`` \| `Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| `Uint8Array`\>
+
+#### Defined in
+
+[keystore/persistence/interface.ts:2](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/interface.ts#L2)
+
+___
+
+### setItem
+
+**setItem**(`key`, `value`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+| `value` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[keystore/persistence/interface.ts:3](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/persistence/interface.ts#L3)

--- a/docs/client-sdk/javascript/reference/interfaces/Signer.md
+++ b/docs/client-sdk/javascript/reference/interfaces/Signer.md
@@ -1,0 +1,36 @@
+<!---->
+# Interface: Signer
+
+## Methods
+
+### getAddress
+
+**getAddress**(): `Promise`<`string`\>
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[types/Signer.ts:2](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/types/Signer.ts#L2)
+
+___
+
+### signMessage
+
+**signMessage**(`message`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` \| `ArrayLike`<`number`\> |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[types/Signer.ts:3](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/types/Signer.ts#L3)

--- a/docs/client-sdk/javascript/reference/interfaces/_category_.json
+++ b/docs/client-sdk/javascript/reference/interfaces/_category_.json
@@ -1,5 +1,5 @@
 {
- "label": "Interfaces",
- "position": 2,
- "collapsible": false,
+    "label": "Interfaces",
+    "position": 2,
+    "collapsible": false,
 }

--- a/docs/client-sdk/javascript/reference/modules.md
+++ b/docs/client-sdk/javascript/reference/modules.md
@@ -7,14 +7,14 @@ sidebar_position: 3
 
 ### ClientOptions
 
- **ClientOptions**: `NetworkOptions` & `KeyStoreOptions` & `ContentOptions` & `LegacyOptions`
+ **ClientOptions**: `Flatten`<[`NetworkOptions`](modules.md#networkoptions) & [`KeyStoreOptions`](modules.md#keystoreoptions) & [`ContentOptions`](modules.md#contentoptions) & [`LegacyOptions`](modules.md#legacyoptions) & `PreEventCallbackOptions`\>
 
 Aggregate type for client options. Optional properties are used when the default value is calculated on invocation, and are computed
 as needed by each function. All other defaults are specified in defaultOptions.
 
 #### Defined in
 
-[Client.ts:110](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L110)
+[Client.ts:168](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L168)
 
 ___
 
@@ -24,17 +24,58 @@ ___
 
 #### Defined in
 
-[codecs/Composite.ts:24](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L24)
+[codecs/Composite.ts:24](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L24)
 
 ___
 
-### Conversation
+### ContentOptions
 
- **Conversation**: `ConversationV1` \| `ConversationV2`
+ **ContentOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `codecs` | [`ContentCodec`](interfaces/ContentCodec.md)<`any`\>[] | Allow configuring codecs for additional content types |
+| `maxContentSize` | `number` | Set the maximum content size in bytes that is allowed by the Client. Currently only checked when decompressing compressed content. |
 
 #### Defined in
 
-[conversations/Conversation.ts:352](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/conversations/Conversation.ts#L352)
+[Client.ts:109](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L109)
+
+___
+
+### KeyStoreOptions
+
+ **KeyStoreOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `keystoreProviders` | [`KeystoreProvider`](interfaces/KeystoreProvider.md)[] | Provide an array of KeystoreProviders. The client will attempt to use each one in sequence until one successfully returns a Keystore instance |
+| `persistConversations` | `boolean` | Enable the Keystore to persist conversations in the provided storage interface |
+| `privateKeyOverride?` | `Uint8Array` | Provide a XMTP PrivateKeyBundle encoded as a Uint8Array. A bundle can be retried using `Client.getKeys(...)` |
+
+#### Defined in
+
+[Client.ts:123](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L123)
+
+___
+
+### LegacyOptions
+
+ **LegacyOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `publishLegacyContact?` | `boolean` |
+
+#### Defined in
+
+[Client.ts:141](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L141)
 
 ___
 
@@ -54,7 +95,7 @@ ___
 
 #### Defined in
 
-[Client.ts:45](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L45)
+[Client.ts:40](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L40)
 
 ___
 
@@ -64,7 +105,28 @@ ___
 
 #### Defined in
 
-[Message.ts:245](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Message.ts#L245)
+[Message.ts:229](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L229)
+
+___
+
+### NetworkOptions
+
+ **NetworkOptions**: `Object`
+
+Network startup options
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `apiUrl` | `string` \| `undefined` | apiUrl can be used to override the `env` flag and connect to a specific endpoint |
+| `appVersion?` | `string` | identifier that's included with API requests. For example, you can use the following format: `appVersion: APP_NAME + '/' + APP_VERSION`. Setting this value provides telemetry that shows which apps are using the XMTP client SDK. This information can help XMTP developers provide app support, especially around communicating important SDK updates, including deprecations and required upgrades. |
+| `env` | `XmtpEnv` | Specify which XMTP environment to connect to. (default: `dev`) |
+| `skipContactPublishing` | `boolean` | Skip publishing the user's contact bundle as part of Client startup. This flag should be used with caution, as we rely on contact publishing to let other users know your public key and periodically run migrations on this data with new SDK versions. Your application should have this flag set to `false` at least _some_ of the time. The most common use-case for setting this to `true` is cases where the Client instance is very short-lived. For example, spinning up a Client to decrypt a push notification. |
+
+#### Defined in
+
+[Client.ts:71](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L71)
 
 ___
 
@@ -74,7 +136,7 @@ ___
 
 #### Defined in
 
-[crypto/PrivateKeyBundle.ts:232](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/crypto/PrivateKeyBundle.ts#L232)
+[crypto/PrivateKeyBundle.ts:414](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/PrivateKeyBundle.ts#L414)
 
 ___
 
@@ -86,16 +148,63 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `compression?` | `xmtpEnvelope.Compression` |
+| `compression?` | `proto.Compression` |
 | `contentFallback?` | `string` |
 | `contentType?` | [`ContentTypeId`](classes/ContentTypeId.md) |
+| `ephemeral?` | `boolean` |
 | `timestamp?` | `Date` |
 
 #### Defined in
 
-[Client.ts:67](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L67)
+[Client.ts:57](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L57)
+
+___
+
+### TopicData
+
+ **TopicData**: `WithoutUndefined`<`keystore.TopicMap_TopicData`\>
+
+#### Defined in
+
+[keystore/interfaces.ts:71](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/keystore/interfaces.ts#L71)
+
+___
+
+### TypingNotification
+
+ **TypingNotification**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `isFinished` | `boolean` |
+| `timestamp` | `Date` |
+| `typerAddress` | `string` |
+
+#### Defined in
+
+[codecs/TypingNotification.ts:13](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/TypingNotification.ts#L13)
 
 ## Variables
+
+### ApiUrls
+
+ `Const` **ApiUrls**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `dev` | ``"https://dev.xmtp.network"`` |
+| `local` | ``"http://localhost:5555"`` |
+| `production` | ``"https://production.xmtp.network"`` |
+
+#### Defined in
+
+[ApiClient.ts:17](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/ApiClient.ts#L17)
+
+___
 
 ### Compression
 
@@ -103,7 +212,7 @@ ___
 
 #### Defined in
 
-[Client.ts:29](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/Client.ts#L29)
+[Client.ts:30](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Client.ts#L30)
 
 ___
 
@@ -113,7 +222,7 @@ ___
 
 #### Defined in
 
-[codecs/Composite.ts:15](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Composite.ts#L15)
+[codecs/Composite.ts:15](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Composite.ts#L15)
 
 ___
 
@@ -123,7 +232,7 @@ ___
 
 #### Defined in
 
-[MessageContent.ts:56](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/MessageContent.ts#L56)
+[MessageContent.ts:56](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/MessageContent.ts#L56)
 
 ___
 
@@ -133,7 +242,17 @@ ___
 
 #### Defined in
 
-[codecs/Text.ts:6](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/codecs/Text.ts#L6)
+[codecs/Text.ts:6](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/Text.ts#L6)
+
+___
+
+### ContentTypeTypingNotification
+
+ `Const` **ContentTypeTypingNotification**: [`ContentTypeId`](classes/ContentTypeId.md)
+
+#### Defined in
+
+[codecs/TypingNotification.ts:6](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/codecs/TypingNotification.ts#L6)
 
 ___
 
@@ -143,9 +262,50 @@ ___
 
 #### Defined in
 
-[ApiClient.ts:7](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/ApiClient.ts#L7)
+[ApiClient.ts:9](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/ApiClient.ts#L9)
 
 ## Functions
+
+### buildDirectMessageTopic
+
+**buildDirectMessageTopic**(`sender`, `recipient`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `sender` | `string` |
+| `recipient` | `string` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[utils/topic.ts:6](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/topic.ts#L6)
+
+___
+
+### buildDirectMessageTopicV2
+
+**buildDirectMessageTopicV2**(`randomString`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `randomString` | `string` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[utils/topic.ts:16](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/topic.ts#L16)
+
+___
 
 ### dateToNs
 
@@ -163,7 +323,72 @@ ___
 
 #### Defined in
 
-[utils.ts:110](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/utils.ts#L110)
+[utils/date.ts:3](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/date.ts#L3)
+
+___
+
+### decodeContent
+
+**decodeContent**(`contentBytes`, `client`): `Promise`<{ `content`: `any` ; `contentType`: [`ContentTypeId`](classes/ContentTypeId.md) ; `error`: `undefined` \| `Error`  }\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `contentBytes` | `Uint8Array` |
+| `client` | [`Client`](classes/Client.md) |
+
+#### Returns
+
+`Promise`<{ `content`: `any` ; `contentType`: [`ContentTypeId`](classes/ContentTypeId.md) ; `error`: `undefined` \| `Error`  }\>
+
+#### Defined in
+
+[Message.ts:373](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/Message.ts#L373)
+
+___
+
+### decrypt
+
+**decrypt**(`encrypted`, `secret`, `additionalData?`): `Promise`<`Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `encrypted` | `Ciphertext` \| [`Ciphertext`](classes/Ciphertext.md) |
+| `secret` | `Uint8Array` |
+| `additionalData?` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<`Uint8Array`\>
+
+#### Defined in
+
+[crypto/encryption.ts:47](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/encryption.ts#L47)
+
+___
+
+### encrypt
+
+**encrypt**(`plain`, `secret`, `additionalData?`): `Promise`<[`Ciphertext`](classes/Ciphertext.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `plain` | `Uint8Array` |
+| `secret` | `Uint8Array` |
+| `additionalData?` | `Uint8Array` |
+
+#### Returns
+
+`Promise`<[`Ciphertext`](classes/Ciphertext.md)\>
+
+#### Defined in
+
+[crypto/encryption.ts:24](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/encryption.ts#L24)
 
 ___
 
@@ -183,7 +408,60 @@ ___
 
 #### Defined in
 
-[utils.ts:122](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/utils.ts#L122)
+[utils/date.ts:15](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/date.ts#L15)
+
+___
+
+### getRandomValues
+
+**getRandomValues**<`T`\>(`array`): `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends ``null`` \| `ArrayBufferView` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `array` | `T` |
+
+#### Returns
+
+`T`
+
+#### Defined in
+
+[crypto/utils.ts:4](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/crypto/utils.ts#L4)
+
+___
+
+### mapPaginatedStream
+
+**mapPaginatedStream**<`Out`\>(`gen`, `mapper`): `AsyncGenerator`<`Out`[]\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `Out` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `gen` | `AsyncGenerator`<`Envelope`[], `any`, `unknown`\> |
+| `mapper` | `EnvelopeMapper`<`Out`\> |
+
+#### Returns
+
+`AsyncGenerator`<`Out`[]\>
+
+#### Defined in
+
+[utils/async.ts:56](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/async.ts#L56)
 
 ___
 
@@ -203,7 +481,7 @@ ___
 
 #### Defined in
 
-[utils.ts:114](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/utils.ts#L114)
+[utils/date.ts:7](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/date.ts#L7)
 
 ___
 
@@ -223,4 +501,4 @@ ___
 
 #### Defined in
 
-[utils.ts:118](https://github.com/xmtp/xmtp-js/blob/b6e743a/src/utils.ts#L118)
+[utils/date.ts:11](https://github.com/xmtp/xmtp-js/blob/ff53c33/src/utils/date.ts#L11)


### PR DESCRIPTION
Update xmtp-js SDK reference docs to reflect v8 functionality.

Preview: https://junk-range-possible-git-v8-ref-docs-xmtp-labs.vercel.app/docs/client-sdk/javascript/reference/classes/Ciphertext