### PR TITLE
Address :chefs-kiss: feedback from UXR

### DIFF
--- a/docs/client-sdk/javascript/tutorials/quickstart.md
+++ b/docs/client-sdk/javascript/tutorials/quickstart.md
@@ -22,9 +22,13 @@ To learn more about XMTP and get answers to frequently asked questions, see [FAQ
 
 ## Example apps built with `xmtp-js`
 
-- [XMTP Quickstart React app](https://github.com/xmtp/xmtp-quickstart-react): Provides a basic messaging app demonstrating core capabilities of the SDK. The app is intentionally built with lightweight code to help make it easier to parse and start learning to build with XMTP.
+- **XMTP Quickstart React app**: Provides a basic messaging app demonstrating core capabilities of the SDK. The app is intentionally built with lightweight code to help make it easier to parse and start learning to build with XMTP.
+  - [Try the app](https://xmtp-quickstart-react.vercel.app/)
+  - [View the repo](https://github.com/xmtp/xmtp-quickstart-react)
 
-- [XMTP Inbox app](https://github.com/xmtp-labs/xmtp-inbox-web): Provides a messaging app demonstrating core and advanced capabilities of the SDK. The app aims to showcase innovative ways of building with XMTP.
+- **XMTP Inbox app**: Provides a messaging app demonstrating core and advanced capabilities of the SDK. The app aims to showcase innovative ways of building with XMTP.
+  - [Try the app](https://xmtp.chat/inbox)
+  - [View the repo](https://github.com/xmtp-labs/xmtp-inbox-web)
 
 ## Reference docs
 

--- a/docs/client-sdk/react/tutorials/quickstart.md
+++ b/docs/client-sdk/react/tutorials/quickstart.md
@@ -8,7 +8,7 @@ toc_max_heading_level: 4
 
 ![Status](https://img.shields.io/badge/Project_Status-Developer_Preview-yellow)
 
-This package provides the XMTP client SDK for React apps written in TypeScript.
+This package provides the [XMTP client SDK for React apps](https://github.com/xmtp/xmtp-web/tree/main/packages/react-sdk) written in TypeScript.
 
 This SDK is in **Developer Preview** status and ready for you to start building with.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -178,7 +178,7 @@ const config = {
             position: 'right',
             items: [
               {
-                to: 'docs/client-sdk/javascript/concepts/intro-to-sdk',
+                to: 'docs/client-sdk/javascript/tutorials/quickstart',
                 html: `<div class="navbar__client__dropdown"><div class="navbar__client__dropdown__icon"><img src="/img/javascript-icon.svg" alt="JavaScript icon" /></div>
                  <div class="navbar__client__dropdown_text"><div class="text-base text-semibold">JavaScript XMTP client SDK</div>
                  <div class="subtext text-sm text-normal whitespace-pre-line">Tutorials and reference for building apps in JavaScript</div></div></div>`,


### PR DESCRIPTION
- Update Documentation -> JavaScript top nav to link to the Quickstart instead of to the Intro concept: [Preview](https://junk-range-possible-git-uxr-feedback-xmtp-labs.vercel.app/)
- Update the JavaScript Quickstart to link to not just the example app repos, but to the apps themselves: [Preview](https://junk-range-possible-git-uxr-feedback-xmtp-labs.vercel.app/docs/client-sdk/javascript/tutorials/quickstart#example-apps-built-with-xmtp-js)
- Update the React SDK Quickstart to link explicitly to the SDK repo: [Preview](https://junk-range-possible-git-uxr-feedback-xmtp-labs.vercel.app/docs/client-sdk/react/tutorials/quickstart)