### PR TITLE
Fix package name for bot starter

### DIFF
--- a/docs/tutorials/bots.md
+++ b/docs/tutorials/bots.md
@@ -19,7 +19,7 @@ This project is **alpha** status and ready for you to start experimenting with. 
 
 ```typescript
 // TODO: this isn't actually published yet.
-import run from "xmtp-bot-starter";
+import run from "@xmtp/bot-starter";
 
 // Call `run` with a handler function. The handler function is called
 // with a HandlerContext


### PR DESCRIPTION
## Summary

We just published v1.0 of this package. For consistency with our other NPM packages, I am putting it under our NPM org (`@xmtp/bot-starter`) instead of what is in the docs `xmtp-bot-starter`.