### PR TITLE
Added title and description to the page attributes

### DIFF
--- a/src/pages/built-with-xmtp.mdx
+++ b/src/pages/built-with-xmtp.mdx
@@ -1,5 +1,7 @@
 ---
 hide_table_of_contents: true
+title: Built with XMTP
+description: Hundreds of awesome projects, people, and partners rely on XMTP. Come build with us!
 ---
 
 import BuiltWithXmtp from "@site/src/components/BuiltWithXmtp";


### PR DESCRIPTION
During the last update, the page title was lost on the "Built with XMTP" page. This update adds that back in.