### PR TITLE
Fix kotlin and dart Quickstart links

### DIFF
--- a/src/components/Quickstarts/index.md
+++ b/src/components/Quickstarts/index.md
@@ -2,8 +2,8 @@
 
 - [ReactJS](https://github.com/fabriguespe/xmtp-quickstart-reactjs) / [NextJS](https://github.com/fabriguespe/xmtp-quickstart-nextjs) / [React Hooks](https://github.com/fabriguespe/xmtp-quickstart-hooks)
 - [VueJS](https://github.com/fabriguespe/xmtp-quickstart-vuejs) / [NuxtJS](https://github.com/fabriguespe/xmtp-quickstart-nuxtjs)
-- [Dart](https://github.com/xmtp/xmtp-android)
-- [Kotlin](https://github.com/xmtp/xmtp-flutter)
+- [Dart](https://github.com/xmtp/xmtp-flutter)
+- [Kotlin](https://github.com/xmtp/xmtp-android)
 - [Swift](https://github.com/xmtp/xmtp-ios)
 - [React Native](https://github.com/fabriguespe/xmtp-react-native-quickstart)
 - [Firebase Functions](https://github.com/fabriguespe/xmtp-firebase-functions) / [NodeJS](https://github.com/fabriguespe/xmtp-quickstart-node)


### PR DESCRIPTION
They are swapped, `Dart` should link to flutter and `Kotlin` should link to android