### PR TITLE
Update group chat instructions

### DIFF
--- a/docs/build/group-chats.md
+++ b/docs/build/group-chats.md
@@ -11,7 +11,7 @@ This feature is in **alpha** status and ready for you to start experimenting w
 :::
 
 ```bash
-git clone -b beta https://github.com/xmtp/xmtp-js.git
+npm i --save @xmtp/xmtp-js@9.4.0-beta.1
 ```
 
 - `GroupConversation` is similar to `ConversationV1` or `ConversationV2` provided by the SDK. These conversations are just a way to send and receive messages.


### PR DESCRIPTION
## Summary

The previous instructions were for developers to clone the repo to get access to group chat. This is frustrating, because developers would then have to build it themselves and use NPM link. A more straightforward option exists, which is to use the `beta` tag in NPM which has access to the group chat features as normal NPM packages.