### PR TITLE
Add reload logic for tutorial

### DIFF
--- a/src/components/Tutorial/index.js
+++ b/src/components/Tutorial/index.js
@@ -7,6 +7,18 @@ const Tutorial = () => {
   );
 
   useEffect(() => {
+    // This is a temporary fix required for loading the tutorial in iframe
+    if (localStorage.getItem("loaded_tutorial") !== "true") {
+      localStorage.setItem("loaded_tutorial", "true");
+      window.location.reload();
+    }
+    return () => {
+      localStorage.removeItem("loaded_tutorial");
+      window.location.reload();
+    };
+  }, []);
+
+  useEffect(() => {
     // Add mutation handling for the data-theme in the html. Needed so we can pass appropriate dark/light mode to iframe.
     const handleMutations = (mutationsList, observer) => {
       for (let mutation of mutationsList) {


### PR DESCRIPTION
Refreshes page when component mounts and unmounts. This is a required workaround due to side effects of setting cross-origin isolated headers in only one route. While it is not ideal, it seemed to be the best option given tradeoffs of alternatives. 