### PR TITLE
Tab hygiene

### DIFF
--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -293,7 +293,7 @@ let client = try Client.from(bundle: keys, options: .init(api: .init(env: .produ
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>

--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -29,53 +29,6 @@ const xmtp = await Client.create(wallet, { env: "dev" });
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-import XMTP
-
-// Create the client with a `SigningKey` from your app
-let client = try await Client.create(
-  account: account, options: .init(api: .init(env: .production)))
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-/*The client has two constructors: `createFromWallet` and `createFromKeys`.
-
-The first time a user uses a new device, they should call `createFromWallet`. This will prompt them
-to sign a message to do one of the following: Create a new identity (if they're new) or enable their existing identity (if they've used XMTP before)
-
-When this succeeds, it configures the client with a bundle of `keys` that can be stored securely on
-the device.*/
-
-var api = xmtp.Api.create();
-var client = await Client.createFromWallet(api, wallet);
-await mySecureStorage.save(client.keys.writeToBuffer());
-
-//The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.
-
-var stored = await mySecureStorage.load();
-var keys = xmtp.PrivateKeyBundle.fromBuffer(stored);
-var api = xmtp.Api.create();
-var client = await Client.createFromKeys(api, keys);
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-// Create the client with a `SigningKey` from your app
-val options =
-    ClientOptions(
-        api = ClientOptions.Api(env = XMTPEnvironment.PRODUCTION, isSecure = true)
-    )
-val client = Client().create(account = account, options = options)
-```
-
-</TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 To use the hooks provided by the React SDK, you must wrap your app with an `XMTPProvider`. This gives the hooks access to the XMTP client instance.
@@ -118,6 +71,53 @@ export const CreateClient: React.FC<{ signer: Signer }> = ({ signer }) => {
 
   return "Connected to XMTP";
 };
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+// Create the client with a `SigningKey` from your app
+val options =
+    ClientOptions(
+        api = ClientOptions.Api(env = XMTPEnvironment.PRODUCTION, isSecure = true)
+    )
+val client = Client().create(account = account, options = options)
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+import XMTP
+
+// Create the client with a `SigningKey` from your app
+let client = try await Client.create(
+  account: account, options: .init(api: .init(env: .production)))
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+/*The client has two constructors: `createFromWallet` and `createFromKeys`.
+
+The first time a user uses a new device, they should call `createFromWallet`. This will prompt them
+to sign a message to do one of the following: Create a new identity (if they're new) or enable their existing identity (if they've used XMTP before)
+
+When this succeeds, it configures the client with a bundle of `keys` that can be stored securely on
+the device.*/
+
+var api = xmtp.Api.create();
+var client = await Client.createFromWallet(api, wallet);
+await mySecureStorage.save(client.keys.writeToBuffer());
+
+//The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.
+
+var stored = await mySecureStorage.load();
+var keys = xmtp.PrivateKeyBundle.fromBuffer(stored);
+var api = xmtp.Api.create();
+var client = await Client.createFromKeys(api, keys);
 ```
 
 </TabItem>
@@ -217,25 +217,30 @@ export const wipeKeys = (walletAddress: string) => {
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-```swift
-// Create the client with a `SigningKey` from your app
-let client = try await Client.create(
-  account: account, options: .init(api: .init(env: .production)))
+```tsx
+import { Client, useClient } from "@xmtp/react-sdk";
+import type { Signer } from "@xmtp/react-sdk";
 
-// Get the key bundle
-let keys = client.privateKeyBundle
+export const CreateClientWithKeys: React.FC<{ signer: Signer }> = ({ signer }) => {
+  const { initialize } = useClient();
 
-// Serialize the key bundle and store it somewhere safe
-let keysData = try keys.serializedData()
-```
+  // initialize client on mount
+  useEffect(() => {
+    const init = async () => {
+      // get the keys using a valid Signer
+      const keys = await Client.getKeys(signer);
+      // create a client using keys returned from getKeys
+      await initialize({ keys, signer });
+    };
+    void init();
+  }, []);
 
-Once you have those keys, you can create a new client with `Client.from`:
-
-```swift
-let keys = try PrivateKeyBundle(serializedData: keysData)
-let client = try Client.from(bundle: keys, options: .init(api: .init(env: .production)))
+  return (
+    ...
+  );
+};
 ```
 
 </TabItem>
@@ -264,31 +269,31 @@ val client = Client().buildFrom(bundle = keys, options = options)
 ```
 
 </TabItem>
-<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-```tsx
-import { Client, useClient } from "@xmtp/react-sdk";
-import type { Signer } from "@xmtp/react-sdk";
+```swift
+// Create the client with a `SigningKey` from your app
+let client = try await Client.create(
+  account: account, options: .init(api: .init(env: .production)))
 
-export const CreateClientWithKeys: React.FC<{ signer: Signer }> = ({ signer }) => {
-  const { initialize } = useClient();
+// Get the key bundle
+let keys = client.privateKeyBundle
 
-  // initialize client on mount
-  useEffect(() => {
-    const init = async () => {
-      // get the keys using a valid Signer
-      const keys = await Client.getKeys(signer);
-      // create a client using keys returned from getKeys
-      await initialize({ keys, signer });
-    };
-    void init();
-  }, []);
-
-  return (
-    ...
-  );
-};
+// Serialize the key bundle and store it somewhere safe
+let keysData = try keys.serializedData()
 ```
+
+Once you have those keys, you can create a new client with `Client.from`:
+
+```swift
+let keys = try PrivateKeyBundle(serializedData: keysData)
+let client = try Client.from(bundle: keys, options: .init(api: .init(env: .production)))
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
@@ -334,29 +339,20 @@ Set the `env` client option to `dev` while developing. Set it to `production` be
 | apiClientFactory          | `HttpApiClient`                                                                   | Override the function used to create an API client for the XMTP network. If you are running `xmtp-js` on a server, you will want to import [`@xmtp/grpc-api-client`](https://github.com/xmtp/bot-kit-pro) and set this option to `GrpcApiClient.fromOptions` for better performance and reliability. To learn more, see [Pluggable gRPC API client](https://github.com/xmtp/xmtp-js/releases/tag/v11.0.0).                  |
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-| Parameter  | Default     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| appVersion | `undefined` | Add a client app version identifier that's included with API requests. **Production apps are strongly encouraged to set this value.**<br/>For example, you can use the following format: `appVersion: APP_NAME + '/' + APP_VERSION`.<br/>Setting this value provides telemetry that shows which apps are using the XMTP client SDK. This information can help XMTP developers provide app support, especially around communicating important SDK updates, including deprecations and required upgrades. |
-| env        | `dev`       | Connect to the specified XMTP network environment. Valid values include `.dev`, `.production`, or `.local`. For important details about working with these environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments).                                                                                                                                                                                                                         |
-
-**Configure `env`**
-
-```swift
-// Configure the client to use the `production` network
-let clientOptions = ClientOptions(api: .init(env: .production))
-let client = try await Client.create(account: account, options: clientOptions)
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-You can configure the client environment when you call `Api.create()`.
-
-By default, it will connect to a `local` XMTP network.
-
-For important details about connecting to environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments).
+| Parameter                 | Default                                                                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appVersion                | undefined                                                                       | Add a client app version identifier that's included with API requests.<br/>For example, you can use the following format: appVersion: APP_NAME + '/' + APP_VERSION.<br/>Setting this value provides telemetry that shows which apps are using the XMTP client SDK. This information can help XMTP developers provide app support, especially around communicating important SDK updates, including deprecations and required upgrades. |
+| env                       | dev                                                                             | Connect to the specified XMTP network environment. Valid values include dev, production, or local. For important details about working with these environments, see [XMTP production and dev network environments](https://github.com/xmtp/xmtp-web/blob/main/packages/react-sdk/README.md#xmtp-production-and-dev-network-environments).                                                                                              |
+| apiUrl                    | undefined                                                                       | Manually specify an API URL to use. If specified, value of env will be ignored.                                                                                                                                                                                                                                                                                                                                                        |
+| keystoreProviders         | [StaticKeystoreProvider, NetworkKeystoreProvider, KeyGeneratorKeystoreProvider] | Override the default behavior of how the client creates a Keystore with a custom provider. This can be used to get the user's private keys from a different storage mechanism.                                                                                                                                                                                                                                                         |
+| persistConversations      | true                                                                            | Maintain a cache of previously seen V2 conversations in the storage provider (defaults to LocalStorage).                                                                                                                                                                                                                                                                                                                               |
+| skipContactPublishing     | false                                                                           | Do not publish the user's contact bundle to the network on client creation. Designed to be used in cases where the client session is short-lived (for example, decrypting a push notification), and where it is known that a client instance has been instantiated with this flag set to false at some point in the past.                                                                                                              |
+| codecs                    | [TextCodec]                                                                     | Add codecs to support additional content types.                                                                                                                                                                                                                                                                                                                                                                                        |
+| maxContentSize            | 100M                                                                            | Maximum message content size in bytes.                                                                                                                                                                                                                                                                                                                                                                                                 |
+| preCreateIdentityCallback | undefined                                                                       | preCreateIdentityCallback is a function that will be called immediately before a [Create Identity wallet signature](https://xmtp.org/docs/concepts/account-signatures#sign-to-create-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                     |
+| preEnableIdentityCallback | undefined                                                                       | preEnableIdentityCallback is a function that will be called immediately before an [Enable Identity wallet signature](https://xmtp.org/docs/concepts/account-signatures#sign-to-enable-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                    |
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -384,20 +380,29 @@ The `apiUrl`, `keyStoreType`, `codecs`, and `maxContentSize` parameters from the
 :::
 
 </TabItem>
-<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-| Parameter                 | Default                                                                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| appVersion                | undefined                                                                       | Add a client app version identifier that's included with API requests.<br/>For example, you can use the following format: appVersion: APP_NAME + '/' + APP_VERSION.<br/>Setting this value provides telemetry that shows which apps are using the XMTP client SDK. This information can help XMTP developers provide app support, especially around communicating important SDK updates, including deprecations and required upgrades. |
-| env                       | dev                                                                             | Connect to the specified XMTP network environment. Valid values include dev, production, or local. For important details about working with these environments, see [XMTP production and dev network environments](https://github.com/xmtp/xmtp-web/blob/main/packages/react-sdk/README.md#xmtp-production-and-dev-network-environments).                                                                                              |
-| apiUrl                    | undefined                                                                       | Manually specify an API URL to use. If specified, value of env will be ignored.                                                                                                                                                                                                                                                                                                                                                        |
-| keystoreProviders         | [StaticKeystoreProvider, NetworkKeystoreProvider, KeyGeneratorKeystoreProvider] | Override the default behavior of how the client creates a Keystore with a custom provider. This can be used to get the user's private keys from a different storage mechanism.                                                                                                                                                                                                                                                         |
-| persistConversations      | true                                                                            | Maintain a cache of previously seen V2 conversations in the storage provider (defaults to LocalStorage).                                                                                                                                                                                                                                                                                                                               |
-| skipContactPublishing     | false                                                                           | Do not publish the user's contact bundle to the network on client creation. Designed to be used in cases where the client session is short-lived (for example, decrypting a push notification), and where it is known that a client instance has been instantiated with this flag set to false at some point in the past.                                                                                                              |
-| codecs                    | [TextCodec]                                                                     | Add codecs to support additional content types.                                                                                                                                                                                                                                                                                                                                                                                        |
-| maxContentSize            | 100M                                                                            | Maximum message content size in bytes.                                                                                                                                                                                                                                                                                                                                                                                                 |
-| preCreateIdentityCallback | undefined                                                                       | preCreateIdentityCallback is a function that will be called immediately before a [Create Identity wallet signature](https://xmtp.org/docs/concepts/account-signatures#sign-to-create-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                     |
-| preEnableIdentityCallback | undefined                                                                       | preEnableIdentityCallback is a function that will be called immediately before an [Enable Identity wallet signature](https://xmtp.org/docs/concepts/account-signatures#sign-to-enable-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                    |
+| Parameter  | Default     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appVersion | `undefined` | Add a client app version identifier that's included with API requests. **Production apps are strongly encouraged to set this value.**<br/>For example, you can use the following format: `appVersion: APP_NAME + '/' + APP_VERSION`.<br/>Setting this value provides telemetry that shows which apps are using the XMTP client SDK. This information can help XMTP developers provide app support, especially around communicating important SDK updates, including deprecations and required upgrades. |
+| env        | `dev`       | Connect to the specified XMTP network environment. Valid values include `.dev`, `.production`, or `.local`. For important details about working with these environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments).                                                                                                                                                                                                                         |
+
+**Configure `env`**
+
+```swift
+// Configure the client to use the `production` network
+let clientOptions = ClientOptions(api: .init(env: .production))
+let client = try await Client.create(account: account, options: clientOptions)
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+You can configure the client environment when you call `Api.create()`.
+
+By default, it will connect to a `local` XMTP network.
+
+For important details about connecting to environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments).
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>

--- a/docs/build/conversations.md
+++ b/docs/build/conversations.md
@@ -354,17 +354,17 @@ val client.importConversation(conversations)
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 </Tabs>
@@ -382,6 +382,28 @@ Not applicable
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 Not applicable
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+// Get a conversation
+val conversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+// Dump it to JSON
+val gson = GsonBuilder().create()
+val data = gson.toJson(conversation)
+
+// Get it back from JSON
+val containerAgain =
+    gson.fromJson(data.toString(StandardCharsets.UTF_8), ConversationV2Export::class.java)
+
+// Get an actual Conversation object like we had above
+val decodedConversation = containerAgain.decode(client)
+
+decodedConversation.send(text = "hi")
+```
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
@@ -408,36 +430,14 @@ try await decodedConversation.send(text: "hi")
 ```
 
 </TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-// Get a conversation
-val conversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-// Dump it to JSON
-val gson = GsonBuilder().create()
-val data = gson.toJson(conversation)
-
-// Get it back from JSON
-val containerAgain =
-    gson.fromJson(data.toString(StandardCharsets.UTF_8), ConversationV2Export::class.java)
-
-// Get an actual Conversation object like we had above
-val decodedConversation = containerAgain.decode(client)
-
-decodedConversation.send(text = "hi")
-```
-
-</TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 </Tabs>

--- a/docs/build/conversations.md
+++ b/docs/build/conversations.md
@@ -26,28 +26,6 @@ const isOnProdNetwork = await client.canMessage(
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-let canAliceMessageBob = try await client.canMessage(bobClient.address)
-```
-
-</TabItem>
-
-<TabItem value="dart" label="Dart" attributes={{className: "dart_tab"}}>
-
-```dart
- val canMessage = client.canMessage(fixtures.bobClient.address)
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
- val canMessage = client.canMessage(bobClient.address)
-```
-
-</TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```tsx
@@ -91,6 +69,27 @@ export const CanMessage: React.FC = () => {
 ```
 
 </TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+ val canMessage = client.canMessage(bobClient.address)
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+let canAliceMessageBob = try await client.canMessage(bobClient.address)
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart" attributes={{className: "dart_tab"}}>
+
+```dart
+ val canMessage = client.canMessage(fixtures.bobClient.address)
+```
+
+</TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx
@@ -121,29 +120,6 @@ You can create a new conversation with any address activated on the XMTP network
 const newConversation = await xmtp.conversations.newConversation(
   "0x937C0d4a6294cdfa575de17382c7076b579DC176",
 );
-```
-
-  </TabItem>
-  <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-let newConversation = try await client.conversations.newConversation(
-  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-var convo = await client.newConversation("0x...");
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-val newConversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
 ```
 
 </TabItem>
@@ -205,6 +181,29 @@ export const StartConversation: React.FC = () => {
 };
 ```
 
+</TabItem>  
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+val newConversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+```
+
+</TabItem>
+  <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+let newConversation = try await client.conversations.newConversation(
+  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+var convo = await client.newConversation("0x...");
+```
+
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
@@ -242,6 +241,39 @@ for (const conversation of allConversations) {
 ```
 
 </TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+```tsx
+export const ListConversations: React.FC = () => {
+  const { conversations, error, isLoading } = useConversations();
+
+  if (error) {
+    return "An error occurred while loading conversations";
+  }
+
+  if (isLoading) {
+    return "Loading conversations...";
+  }
+
+  return (
+    ...
+  );
+};
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+val allConversations = client.conversations.list()
+
+for (conversation in allConversations) {
+    print("Saying GM to ${conversation.peerAddress}")
+    conversation.send(text = "gm")
+}
+```
+
+</TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
@@ -262,39 +294,6 @@ for (var convo in conversations) {
   debugPrint('Saying GM to ${convo.peer}');
   await client.sendMessage(convo, 'gm');
 }
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-val allConversations = client.conversations.list()
-
-for (conversation in allConversations) {
-    print("Saying GM to ${conversation.peerAddress}")
-    conversation.send(text = "gm")
-}
-```
-
-</TabItem>
-<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
-
-```tsx
-export const ListConversations: React.FC = () => {
-  const { conversations, error, isLoading } = useConversations();
-
-  if (error) {
-    return "An error occurred while loading conversations";
-  }
-
-  if (isLoading) {
-    return "Loading conversations...";
-  }
-
-  return (
-    ...
-  );
-};
 ```
 
 </TabItem>
@@ -328,6 +327,17 @@ const clientWithNoCache = await Client.create(wallet, {
 ```
 
 </TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+```tsx
+const { initialize } = useClient();
+const options = {
+  persistConversations: false,
+};
+await initialize({ signer, options });
+```
+
+</TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
@@ -342,15 +352,19 @@ val client.importConversation(conversations)
 ```
 
 </TabItem>
-<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-```tsx
-const { initialize } = useClient();
-const options = {
-  persistConversations: false,
-};
-await initialize({ signer, options });
-```
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+Code sample not available
 
 </TabItem>
 </Tabs>
@@ -360,6 +374,16 @@ await initialize({ signer, options });
 You can save a conversation object locally using its `encodedContainer` property. This returns a `ConversationContainer` object which conforms to `Codable`.
 
 <Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+
+Not applicable
+
+</TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+Not applicable
+
+</TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
@@ -404,6 +428,16 @@ val decodedConversation = containerAgain.decode(client)
 
 decodedConversation.send(text = "hi")
 ```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+Code sample not available
 
 </TabItem>
 </Tabs>

--- a/docs/build/get-started.md
+++ b/docs/build/get-started.md
@@ -46,6 +46,76 @@ for await (const message of await conversation.streamMessages()) {
 ```
 
 </TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+```tsx
+import {
+  Client,
+  useStreamMessages,
+  useClient,
+  useMessages,
+  useConversations,
+  useCanMessage,
+  useStartConversation,
+} from "@xmtp/react-sdk";
+
+const { client, initialize } = useClient();
+const { conversations } = useConversations();
+const { startConversation } = useStartConversation();
+const { canMessage } = useCanMessage();
+
+//Initialize
+{
+  !isConnected && <button onClick={initXmtp}>Connect to XMTP</button>;
+}
+
+const initXmtp = async () => {
+  await initialize({ signer });
+};
+
+// Start a conversation with XMTP
+const add = "0x3F11b27F323b62B159D2642964fa27C46C841897";
+if (await canMessage(add)) {
+  const conversation = await startConversation(add, "hi");
+}
+
+//Stream messages
+const [history, setHistory] = useState(null);
+const { messages } = useMessages(conversation);
+// Stream messages
+const onMessage = useCallback((message) => {
+  setHistory((prevMessages) => {
+    const msgsnew = [...prevMessages, message];
+    return msgsnew;
+  });
+}, []);
+useStreamMessages(conversation, { onMessage });
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+// You'll want to replace this with a wallet from your application.
+val account = PrivateKeyBuilder()
+
+// Create the client with your wallet. This will connect to the XMTP `dev` network by default.
+// The account is anything that conforms to the `XMTP.SigningKey` protocol.
+val client = Client().create(account = account)
+
+// Start a conversation with XMTP
+val conversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+// Load all messages in the conversation
+val messages = conversation.messages()
+// Send a message
+conversation.send(text = "gm")
+// Listen for new messages in the conversation
+conversation.streamMessages().collect { print("${message.senderAddress}: ${message.body}") }
+```
+
+</TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
@@ -111,76 +181,6 @@ await listening.cancel();
 ```
 
 </TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-// You'll want to replace this with a wallet from your application.
-val account = PrivateKeyBuilder()
-
-// Create the client with your wallet. This will connect to the XMTP `dev` network by default.
-// The account is anything that conforms to the `XMTP.SigningKey` protocol.
-val client = Client().create(account = account)
-
-// Start a conversation with XMTP
-val conversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-// Load all messages in the conversation
-val messages = conversation.messages()
-// Send a message
-conversation.send(text = "gm")
-// Listen for new messages in the conversation
-conversation.streamMessages().collect { print("${message.senderAddress}: ${message.body}") }
-```
-
-</TabItem>
-<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
-
-```tsx
-import {
-  Client,
-  useStreamMessages,
-  useClient,
-  useMessages,
-  useConversations,
-  useCanMessage,
-  useStartConversation,
-} from "@xmtp/react-sdk";
-
-const { client, initialize } = useClient();
-const { conversations } = useConversations();
-const { startConversation } = useStartConversation();
-const { canMessage } = useCanMessage();
-
-//Initialize
-{
-  !isConnected && <button onClick={initXmtp}>Connect to XMTP</button>;
-}
-
-const initXmtp = async () => {
-  await initialize({ signer });
-};
-
-// Start a conversation with XMTP
-const add = "0x3F11b27F323b62B159D2642964fa27C46C841897";
-if (await canMessage(add)) {
-  const conversation = await startConversation(add, "hi");
-}
-
-//Stream messages
-const [history, setHistory] = useState(null);
-const { messages } = useMessages(conversation);
-// Stream messages
-const onMessage = useCallback((message) => {
-  setHistory((prevMessages) => {
-    const msgsnew = [...prevMessages, message];
-    return msgsnew;
-  });
-}, []);
-useStreamMessages(conversation, { onMessage });
-```
-
-</TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
@@ -227,8 +227,6 @@ function sendMessage(message: string) {
     getMessages(conversation!!);
   };
 }
-
-
 ```
 
 </TabItem>
@@ -246,6 +244,22 @@ npm install @xmtp/xmtp-js
 ```
 
 </TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+```bash
+npm i @xmtp/react-sdk
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+You can find the latest package version on [Maven Central](https://central.sonatype.com/artifact/org.xmtp/android/0.0.5/versions).
+
+```bash
+implementation 'org.xmtp:android:X.X.X'
+```
+
+</TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 Use Xcode to add to the project (**File** > **Add Packages…**) or add this to your `Package.swift file`:
@@ -259,22 +273,6 @@ Use Xcode to add to the project (**File** > **Add Packages…**) or add this to 
 
 ```bash
 flutter pub add xmtp
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-You can find the latest package version on [Maven Central](https://central.sonatype.com/artifact/org.xmtp/android/0.0.5/versions).
-
-```bash
-implementation 'org.xmtp:android:X.X.X'
-```
-
-</TabItem>
-<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
-
-```bash
-npm i @xmtp/react-sdk
 ```
 
 </TabItem>

--- a/docs/build/local-first.md
+++ b/docs/build/local-first.md
@@ -26,9 +26,9 @@ For more performance best practices, see [Optimize performance of your app](/doc
 
 ## Manage local data with Dexie in a web app built with xmtp-js
 
-The performance of a web app can be significantly improved by leveraging local data storage. Particularly in the context of loading messages, using a local cache can result in a 10x performance increase compared to solely relying on a network-based data source.
+You can significantly improve your web app's performance by leveraging local data storage. Particularly in the context of loading messages, using a local cache can result in a 10x performance increase compared to solely relying on a network-based data source.
 
-This guide provides a walkthrough on managing local data storage using the Dexie.js library in a web app built with the [xmtp-js SDK](https://github.com/xmtp/xmtp-js). Dexie.js is a minimalistic wrapper for IndexedDB, which is a low-level API for client-side storage of significant amounts of structured data.
+This guide provides a walkthrough on managing local data storage using the Dexie.js library in a web app built with the [xmtp-js SDK](https://github.com/xmtp/xmtp-js). Dexie.js is a minimalistic wrapper for IndexedDB, a low-level API for client-side storage of significant amounts of structured data.
 
 import ReactPlayer from 'react-player'
 
@@ -328,6 +328,6 @@ async function saveMessage(
 
 ### Conclusion
 
-Managing local data storage in a web app can be complex. However, with Dexie.js and the right strategies for handling database operations, it can be much more manageable. Always remember to handle potential errors and race conditions to ensure the integrity of your data. Now that you've learned these steps, consider trying them out in your own projects. Happy coding!
+Managing local data storage in a web app can be complex. However, it can be much more manageable with Dexie.js and the right strategies for handling database operations. Always remember to handle potential errors and race conditions to ensure the integrity of your data. Now that you've learned these steps, consider trying them out in your own projects. Happy coding!
 
-To learn more aboutDexie.js, see [Getting Started with Dexie.js](https://dexie.org/docs/Tutorial/Getting-started).
+To learn more about Dexie.js, see [Getting Started with Dexie.js](https://dexie.org/docs/Tutorial/Getting-started).

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -27,9 +27,6 @@ await conversation.send("Hello world");
 
 You might want to consider [optimistically sending messages](/docs/tutorials/other/optimistic-sending). This way, the app will not have to wait for the network to process the message first. Optimistic sending is especially useful for mobile apps where the user might have a spotty connection, making the app continue to run with multiple threads.
 
-<Tabs groupId="sdk-langs">
-<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
-
 ```tsx
 // standard (string) message
 const preparedTextMessage = await conversation.prepareMessage(messageText);
@@ -39,35 +36,6 @@ try {
 } catch (e) {
   // handle error, enable canceling and retries (see below)
 }
-```
-
-</TabItem>
-</Tabs>
-</TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-let conversation = try await client.conversations.newConversation(
-  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
-try await conversation.send(content: "Hello world")
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-var convo = await client.newConversation("0x...");
-await client.sendMessage(convo, 'gm');
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-val conversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-conversation.send(text = "Hello world")
 ```
 
 </TabItem>
@@ -131,7 +99,7 @@ export const SendMessage: React.FC<{ conversation: CachedConversation }> = ({
 };
 ```
 
-### Optimistic sending with React
+**Optimistic sending with React**
 
 When a user sends a message with XMTP, they might experience a slight delay between sending the message and seeing their sent message display in their app UI.
 
@@ -141,7 +109,7 @@ The local-first architecture of the React SDK automatically includes optimistic 
 
 Messages in the sending state have their `isSending` property set to `true`.
 
-### Handle messages that fail to send with React
+**Handle messages that fail to send with React**
 
 If a message fails to complete the sending process, you must provide an error state that alerts the user and enables them to either resend the message or cancel sending the message.
 
@@ -153,7 +121,7 @@ If the user cancels sending the message, the message is removed from the convers
 
 Messages that fail to send have their `hasSendError` property set to `true`.
 
-#### Resend a failed message
+**Resend a failed message**
 
 Use the `resendMessage` function from the `useResendMessage` hook to resend a failed message.
 
@@ -162,6 +130,33 @@ const { resendMessage } = useResendMessage();
 
 // resend the message
 resendMessage(failedMessage);
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+val conversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+conversation.send(text = "Hello world")
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+let conversation = try await client.conversations.newConversation(
+  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+try await conversation.send(content: "Hello world")
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+var convo = await client.newConversation("0x...");
+await client.sendMessage(convo, 'gm');
 ```
 
 </TabItem>
@@ -197,33 +192,6 @@ for (const conversation of await xmtp.conversations.list()) {
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-for conversation in client.conversations.list() {
-  let messagesInConversation = try await conversation.messages()
-}
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-// Only show messages from the last 24 hours.
-var messages = await alice.listMessages(convo,
-    start: DateTime.now().subtract(const Duration(hours: 24)));
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-for (conversation in client.conversations.list()) {
-    val messagesInConversation = conversation.messages()
-}
-```
-
-</TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```tsx
@@ -250,6 +218,33 @@ export const Messages: React.FC<{
 ```
 
 </TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+for (conversation in client.conversations.list()) {
+    val messagesInConversation = conversation.messages()
+}
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+for conversation in client.conversations.list() {
+  let messagesInConversation = try await conversation.messages()
+}
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+// Only show messages from the last 24 hours.
+var messages = await alice.listMessages(convo,
+    start: DateTime.now().subtract(const Duration(hours: 24)));
+```
+
+</TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx
@@ -267,6 +262,29 @@ for (const conversation of await xmtp.conversations.list()) {
 If a conversation has a lot of messages, it's more performant to retrieve and process the messages page by page instead of handling all of the messages at once.
 
 <Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+
+Automatically handled by the SDK
+
+</TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+Automatically handled by the SDK
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+Call `conversation.messages(limit: Int, before: Date)` to return the specified number of messages sent before that time.
+
+```kotlin
+val conversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+val messages = conversation.messages(limit = 25)
+val nextPage = conversation.messages(limit = 25, before = messages[0].sent)
+```
+
+</TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 Call `conversation.messages(limit: Int, before: Date)`, which will return the specified number of messages sent before that time.
@@ -289,19 +307,6 @@ of messages sent before that time.
 var messages = await alice.listMessages(convo, limit: 10);
 var nextPage = await alice.listMessages(
     convo, limit: 10, end: messages.last.sentAt);
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-Call `conversation.messages(limit: Int, before: Date)` to return the specified number of messages sent before that time.
-
-```kotlin
-val conversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-val messages = conversation.messages(limit = 25)
-val nextPage = conversation.messages(limit = 25, before = messages[0].sent)
 ```
 
 </TabItem>
@@ -328,12 +333,12 @@ for await (const page of conversation.messages(limit: 25)) {
 
 ## Handle an unsupported content type error
 
-As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types enter the XMTP ecosystem, your app might receive a content type your app doesn't support. This error could crash your app.
-
-To avoid crashing your app, code your app to detect, log, and handle the error. For example:
+As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types enter the XMTP ecosystem, your app might receive a content type your app doesn't support. This could crash your app.
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+
+To avoid crashing your app, code your app to detect, log, and handle the error. For example:
 
 ```jsx
 const codec = xmtp.codecFor(content.contentType);
@@ -342,6 +347,46 @@ if (!codec) {
   throw new Error(fallback);
 }
 ```
+
+</TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+```tsx
+// If you wish to display an unsupported content type, there’s a contentFallback
+// property that may include a useful string. However, it is recommended that 
+// you manually process unsupported content types.
+import { ContentTypeId } from "@xmtp/xmtp-js";
+import { ContentTypeAttachment } from "@xmtp/content-type-remote-attachment";
+
+const MessageContent = ({ message }) => {
+  if (
+    message.content === undefined &&
+    ContentTypeId.fromString(message.contentType).sameAs(ContentTypeAttachment)
+  ) {
+    return "This message contains an attachment, which is not supported by this client.";
+  }
+};
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+Code sample not available
 
 </TabItem>
 </Tabs >

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -371,22 +371,22 @@ const MessageContent = ({ message }) => {
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 </Tabs >

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -69,19 +69,19 @@ createRoot(document.getElementById("root") as HTMLElement).render(
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-Client.register(ReactionCodec());
-```
-
-</TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
 import org.xmtp.android.library.codecs.ReactionCodec
 
 Client.register(codec = ReactionCodec())
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+Client.register(ReactionCodec());
 ```
 
 </TabItem>
@@ -160,6 +160,11 @@ import org.xmtp.android.library.codecs.ReactionCodec
 
 Client.register(codec = ReactionCodec())
 ```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -259,6 +264,11 @@ if (message.contentType == ContentTypeReaction) {
     val reaction: Reaction = reactionCodec.decode(message.content)
 }
 ```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -164,7 +164,7 @@ Client.register(codec = ReactionCodec())
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -268,7 +268,7 @@ if (message.contentType == ContentTypeReaction) {
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -76,7 +76,7 @@ Client.register(codec = ReadReceiptCodec())
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Read receipts for Swift haven't been implemented yet
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -135,7 +135,7 @@ conversation.send(
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Read receipts for Swift haven't been implemented yet
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -214,7 +214,7 @@ if (message.encodedContent.type == ContentTypeReadReceipt) {
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Read receipts for Swift haven't been implemented yet
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -234,8 +234,6 @@ Read receipts for React Native haven't been implemented yet
 A read receipt timestamp shouldn't be displayed. Instead, use it to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the date is lower.
 
 <!--string of the date - should be timestamp? if the string of the date/timestamp is lower than what value?-->
-
-<!--get React and Kotlin code for below-->
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
@@ -264,7 +262,7 @@ Code sample not available
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Read receipts for Swift haven't been implemented yet
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -74,6 +74,11 @@ Client.register(codec = ReadReceiptCodec())
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 Read receipts for Dart haven't been implemented yet.
@@ -128,14 +133,19 @@ conversation.send(
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Read receipts for Dart haven't been implemented yet.
+Read receipts for Dart haven't been implemented yet
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Read receipts for React Native haven't been implemented yet.
+Read receipts for React Native haven't been implemented yet
 
 </TabItem>
 </Tabs>
@@ -202,14 +212,19 @@ if (message.encodedContent.type == ContentTypeReadReceipt) {
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Read receipts for Dart haven't been implemented yet.
+Read receipts for Dart haven't been implemented yet
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Read receipts for React Native haven't been implemented yet.
+Read receipts for React Native haven't been implemented yet
 
 </TabItem>
 </Tabs>
@@ -236,4 +251,30 @@ function checkReadMessages(messages, readReceipt) {
 }
 ```
 
-</TabItem></Tabs>
+</TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Read receipts for Dart haven't been implemented yet
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+Read receipts for React Native haven't been implemented yet
+
+</TabItem>
+</Tabs>

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -76,7 +76,7 @@ Client.register(codec = ReadReceiptCodec())
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Read receipts for Swift haven't been implemented yet
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -135,7 +135,7 @@ conversation.send(
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Read receipts for Swift haven't been implemented yet
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -214,7 +214,7 @@ if (message.encodedContent.type == ContentTypeReadReceipt) {
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Read receipts for Swift haven't been implemented yet
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -252,17 +252,17 @@ function checkReadMessages(messages, readReceipt) {
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Read receipts for Swift haven't been implemented yet
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -72,14 +72,6 @@ createRoot(document.getElementById("root") as HTMLElement).render(
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-Client.register(AttachmentCodec());
-Client.register(RemoteAttachmentCodec());
-```
-
-</TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
@@ -92,7 +84,14 @@ Client.register(codec = RemoteAttachmentCodec())
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
+```swift
+Client.register(AttachmentCodec());
+Client.register(RemoteAttachmentCodec());
+```
+
+</TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 Remote attachments for Dart haven't been implemented yet.
@@ -109,8 +108,8 @@ You don't need to manually register or use the codecs in your app code. You just
 
 ## Send a remote attachment
 
-<Tabs>
-<TabItem value="javascript" label="JavaScript" attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript" attributes={{className: "js_tab"}}>
 
 Load the file. This example uses a web browser to load the file:
 
@@ -226,7 +225,6 @@ await conversation.send(remoteAttachment, {
 ```
 
 </TabItem>
-
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```jsx
@@ -249,6 +247,49 @@ const attachment = {
 const remoteAttachment = RemoteAttachmentCodec.encode(attachment);
 
 sendMessage(remoteAttachment);
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+Create an attachment object:
+
+```kotlin
+val attachment = Attachment(
+filename = "test.txt",
+mimeType = "text/plain",
+data = "hello world".toByteStringUtf8(),
+)
+```
+
+Encode and encrypt an attachment for transport:
+
+```kotlin
+val encodedEncryptedContent = RemoteAttachment.encodeEncrypted(
+content = attachment,
+codec = AttachmentCodec(),
+)
+```
+
+Create a remote attachment from an attachment:
+
+```kotlin
+val remoteAttachment = RemoteAttachment.from(
+    encryptedEncodedContent = encodedEncryptedContent
+)
+remoteAttachment.contentLength = attachment.data.size()
+remoteAttachment.filename = attachment.filename
+```
+
+Send a remote attachment and set the `contentType`:
+
+```kotlin
+val newConversation = client.conversations.newConversation(walletAddress)
+
+newConversation.send(
+content = remoteAttachment,
+options = SendOptions(contentType = ContentTypeRemoteAttachment),
+)
 ```
 
 </TabItem>
@@ -311,49 +352,6 @@ try await conversation.send(
 		contentType: ContentTypeRemoteAttachment,
 		contentFallback: "a description of the image"
 	)
-)
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-Create an attachment object:
-
-```kotlin
-val attachment = Attachment(
-filename = "test.txt",
-mimeType = "text/plain",
-data = "hello world".toByteStringUtf8(),
-)
-```
-
-Encode and encrypt an attachment for transport:
-
-```kotlin
-val encodedEncryptedContent = RemoteAttachment.encodeEncrypted(
-content = attachment,
-codec = AttachmentCodec(),
-)
-```
-
-Create a remote attachment from an attachment:
-
-```kotlin
-val remoteAttachment = RemoteAttachment.from(
-    encryptedEncodedContent = encodedEncryptedContent
-)
-remoteAttachment.contentLength = attachment.data.size()
-remoteAttachment.filename = attachment.filename
-```
-
-Send a remote attachment and set the `contentType`:
-
-```kotlin
-val newConversation = client.conversations.newConversation(walletAddress)
-
-newConversation.send(
-content = remoteAttachment,
-options = SendOptions(contentType = ContentTypeRemoteAttachment),
 )
 ```
 
@@ -440,6 +438,18 @@ if (message.contentType === ContentTypeRemoteAttachment.toString()) {
 ```
 
 </TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+val message = newConversation.messages().first()
+val loadedRemoteAttachment: RemoteAttachment = messages.content()
+loadedRemoteAttachment.fetcher = Fetcher()
+runBlocking {
+  val attachment: Attachment = loadedRemoteAttachment.load()
+}
+```
+
+</TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
@@ -464,18 +474,6 @@ struct ContentView: View {
 	var body: some View {
 		Image(uiImage: UIImage(data: attachment.data))
 	}
-}
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-val message = newConversation.messages().first()
-val loadedRemoteAttachment: RemoteAttachment = messages.content()
-loadedRemoteAttachment.fetcher = Fetcher()
-runBlocking {
-  val attachment: Attachment = loadedRemoteAttachment.load()
 }
 ```
 

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -161,7 +161,7 @@ aliceConversation.send(
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
@@ -261,7 +261,7 @@ if (encodedContent.type == ContentTypeReply) {
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -66,13 +66,6 @@ createRoot(document.getElementById("root") as HTMLElement).render(
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-Client.register(ReplyCodec());
-```
-
-</TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
@@ -82,7 +75,13 @@ Client.register(codec = ReplyCodec())
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
+```swift
+Client.register(ReplyCodec());
+```
+
+</TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 ```dart
@@ -98,7 +97,6 @@ var registry = CodecRegistry()..registerCodec(ReplyCodec());
 The React Native SDK already has the codecs registered.
 
 </TabItem>
-
 </Tabs>
 
 ## Send a reply
@@ -129,7 +127,7 @@ await conversation.send(reply, {
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-```jsx
+```tsx
 import { useSendMessage } from "@xmtp/react-sdk";
 import { ContentTypeReply } from "@xmtp/content-type-reply";
 
@@ -161,6 +159,25 @@ aliceConversation.send(
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+var parentMessageId = "abc123"; // The ID of the message you're replying to
+var replyContent = DecodedContent(contentTypeText, "This is my reply"); // The content of your reply
+
+// Create a Reply instance
+var reply = Reply(parentMessageId, replyContent);
+
+// Send the reply
+await client.sendMessage(conversation, reply, contentType: contentTypeReply);
+```
+
+</TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
@@ -178,20 +195,7 @@ await conversation.send(replyContent);
 ```
 
 </TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-var parentMessageId = "abc123"; // The ID of the message you're replying to
-var replyContent = DecodedContent(contentTypeText, "This is my reply"); // The content of your reply
-
-// Create a Reply instance
-var reply = Reply(parentMessageId, replyContent);
-
-// Send the reply
-await client.sendMessage(conversation, reply, contentType: contentTypeReply);
-```
-
-</TabItem></Tabs>
+</Tabs>
 
 ## Receive a reply
 
@@ -206,7 +210,6 @@ if (message.contentType.sameAs(ContentTypeReply)) {
 ```
 
 </TabItem>
-
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```jsx
@@ -256,6 +259,21 @@ if (encodedContent.type == ContentTypeReply) {
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+var decodedContent = await registry.decode(encoded);
+if (decodedContent.contentType == contentTypeReply) {
+  // The message is a reply.
+}
+```
+
+</TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
@@ -273,19 +291,9 @@ function MessageContents({ content }: { content: MessageContent }) {
 ```
 
 </TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-var decodedContent = await registry.decode(encoded);
-if (decodedContent.contentType == contentTypeReply) {
-  // The message is a reply.
-}
-```
-
-</TabItem>
 </Tabs>
 
-### Display the reply
+## Display the reply
 
 How you choose to display replies in your app is up to you. It might be useful to look at the user experience for replies in popular apps such as Telegram and Discord.
 For example, in Discord, users can reply to individual messages, and the reply provides a link to the original message.

--- a/docs/build/notifications.md
+++ b/docs/build/notifications.md
@@ -97,12 +97,12 @@ let decodedMessage = try conversation.decode(envelope)
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 </Tabs>

--- a/docs/build/notifications.md
+++ b/docs/build/notifications.md
@@ -3,14 +3,16 @@ sidebar_label: Notifications
 sidebar_position: 20
 ---
 
-# Build push notifications with XMTP
-
-Push notifications can be a highly effective way to engage your users and increase app retention.
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 import pushnotifsettings from '/docs/concepts/img/push-notif-settings.png';
 import pushnotifsdecrypted from '/docs/concepts/img/push-notifs-decrypted.jpg';
 import badgingorb from '/docs/concepts/img/badging-orb.jpg';
 import unreadbadge from '/docs/concepts/img/unread-badge.png';
+
+# Build push notifications with XMTP
+
+Push notifications can be a highly effective way to engage your users and increase app retention. In addition to providing push notifications for new messages, provide them for new conversations. 
 
 ## Run your own notification server
 
@@ -57,17 +59,14 @@ Perform this setup to understand how you might want to enable push notifications
 You can decode a single `Envelope` from XMTP using the `decode` method:
 
 <Tabs groupId="sdk-langs">
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-```swift
-let conversation = try await client.conversations.newConversation(
-  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+Not applicable
 
-// Assume this function returns an Envelope that contains a message for the above conversation
-let envelope = getEnvelopeFromXMTP()
+</TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-let decodedMessage = try conversation.decode(envelope)
-```
+Not applicable
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -83,11 +82,30 @@ val decodedMessage = conversation.decode(envelope)
 ```
 
 </TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+let conversation = try await client.conversations.newConversation(
+  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+// Assume this function returns an Envelope that contains a message for the above conversation
+let envelope = getEnvelopeFromXMTP()
+
+let decodedMessage = try conversation.decode(envelope)
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+Code sample not available
+
+</TabItem>
 </Tabs>
-
-## React Native
-
-In addition to providing push notifications for new messages, provide them for new conversations. To learn more, see [A practical guide to building a push notification client](https://github.com/xmtp/example-notification-server-go/blob/main/docs/notifications-client-guide.md). This guide is based on a React Native example, but can serve as a reference for how you might provide a notification client in your language of choice.
 
 ## Android
 
@@ -137,17 +155,21 @@ Here are some sample answers to help you complete the application:
 - **When your extension runs, what system and network resources does it need?** We might need to make a GRPC request in order to load additional information about a conversation. This is only necessary when we haven't stored the conversation details locally, which is expected to be less common than being able to just decode the conversation locally.
 - **How often does your extension run? What can trigger it to run?** The extension will run whenever a message is sent or received in a conversation. The frequency will depend on how active a user is.
 
-## Scale
+## React Native
+
+See [A practical guide to building a push notification client](https://github.com/xmtp/example-notification-server-go/blob/main/docs/notifications-client-guide.md). This guide is based on a React Native example, but can serve as a reference for how you might provide a notification client in your language of choice.
+
+## Best practices for notifications
 
 - Display push notifications only for messages sent **to** a user. In other words, do not send a push notification to a user about a message they sent. To do this, filter out messages sent by the user and don't send push notifications for them.
 
 - Provide a separate setting for enabling and disabling direct message push notifications. For example, if you’re building a Lens app, provide a setting for XMTP push notifications that’s separate from Lens push notifications for posts, comments, likes, and so forth. For example, here are push notification settings in the Orb app:
 
-<img src={pushnotifsettings} style={{width:"300px"}}/>
+  <img src={pushnotifsettings} style={{width:"300px"}}/>
 
 - Decrypt messages for push notifications so you can display the contents within the notification. For example, here is a decrypted push notification provided by the [Converse app](https://getconverse.app/).
 
-<img src={pushnotifsdecrypted} style={{width:"300px"}}/>
+  <img src={pushnotifsdecrypted} style={{width:"300px"}}/>
 
 - Display badges that indicate the presence of new notifications, messages, or conversations to help with engagement and interaction success.
 

--- a/docs/build/streams.md
+++ b/docs/build/streams.md
@@ -300,17 +300,17 @@ export const StreamAllMessages: React.FC = () => {
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>

--- a/docs/build/streams.md
+++ b/docs/build/streams.md
@@ -32,44 +32,6 @@ for await (const conversation of stream) {
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-for try await conversation in client.conversations.stream() {
-  print("New conversation started with \(conversation.peerAddress)")
-
-  // Say hello to your new friend
-  try await conversation.send(content: "Hi there!")
-
-  // Break from the loop to stop listening
-  //This stream will continue infinitely
-  break
-}
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-var listening = client.streamConversations().listen((convo) {
-  debugPrint('Got a new conversation with ${convo.peer}');
-});
-// When you want to stop listening:
-await listening.cancel();
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-client.conversations.stream().collect {
-    print("New conversation started with ${it.peerAddress}")
-    // Say hello to your new friend
-    it.send(text = "Hi there!")
-}
-```
-
-</TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```tsx
@@ -100,6 +62,44 @@ export const NewConversations: React.FC = () => {
     ...
   );
 };
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+client.conversations.stream().collect {
+    print("New conversation started with ${it.peerAddress}")
+    // Say hello to your new friend
+    it.send(text = "Hi there!")
+}
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+for try await conversation in client.conversations.stream() {
+  print("New conversation started with \(conversation.peerAddress)")
+
+  // Say hello to your new friend
+  try await conversation.send(content: "Hi there!")
+
+  // Break from the loop to stop listening
+  //This stream will continue infinitely
+  break
+}
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+var listening = client.streamConversations().listen((convo) {
+  debugPrint('Got a new conversation with ${convo.peer}');
+});
+// When you want to stop listening:
+await listening.cancel();
 ```
 
 </TabItem>
@@ -142,50 +142,6 @@ for await (const message of await conversation.streamMessages()) {
 ```
 
 </TabItem>
-<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
-
-```swift
-let conversation = try await client.conversations.newConversation(
-  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-for try await message in conversation.streamMessages() {
-  if message.senderAddress == client.address {
-    // This message was sent from me
-    continue
-  }
-
-  print("New message from \(message.senderAddress): \(message.body)")
-}
-```
-
-</TabItem>
-<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
-
-```dart
-var listening = client.streamMessages(convo).listen((message) {
-  debugPrint('${message.sender}> ${message.content}');
-});
-// When you want to stop listening:
-await listening.cancel();
-```
-
-</TabItem>
-<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
-
-```kotlin
-val conversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-conversation.streamMessages().collect {
-    if (it.senderAddress == client.address) {
-        // This message was sent from me
-    }
-
-    print("New message from ${it.senderAddress}: ${it.body}")
-}
-```
-
-</TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```tsx
@@ -223,6 +179,50 @@ export const StreamMessages: React.FC<{
     ...
   );
 };
+```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+val conversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+conversation.streamMessages().collect {
+    if (it.senderAddress == client.address) {
+        // This message was sent from me
+    }
+
+    print("New message from ${it.senderAddress}: ${it.body}")
+}
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+let conversation = try await client.conversations.newConversation(
+  with: "0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+for try await message in conversation.streamMessages() {
+  if message.senderAddress == client.address {
+    // This message was sent from me
+    continue
+  }
+
+  print("New message from \(message.senderAddress): \(message.body)")
+}
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+```dart
+var listening = client.streamMessages(convo).listen((message) {
+  debugPrint('${message.sender}> ${message.content}');
+});
+// When you want to stop listening:
+await listening.cancel();
 ```
 
 </TabItem>
@@ -296,6 +296,21 @@ export const StreamAllMessages: React.FC = () => {
   );
 };
 ```
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>

--- a/docs/tutorials/broadcast.md
+++ b/docs/tutorials/broadcast.md
@@ -53,6 +53,26 @@ main();
 ```
 
 </TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+Code sample not available
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample not available
+
+</TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx

--- a/docs/tutorials/broadcast.md
+++ b/docs/tutorials/broadcast.md
@@ -55,22 +55,22 @@ main();
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample not available
+Code sample coming soon
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>


### PR DESCRIPTION
- Some tabs weren't automatically switching to currently selected language - just a config thing.
- Put tabs in consistent order - web (JS, React) and then mobile (Kotlin, Swift, Dart, RN) in order of popularity per repo stars and release status
- Provided all tabs even if no code sample is available, applicable, or the feature hasn't been implemented for the SDK yet. I've inventoried the missing code samples and we can gather them. I think providing all of the tabs in every case, with an explanation when no code sample is available, is helpful for consistency and orientation.