### PR TITLE
Update some React docs

### DIFF
--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -195,13 +195,27 @@ for (const conversation of await xmtp.conversations.list()) {
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```tsx
+import { useCallback } from "react";
 import { useMessages } from "@xmtp/react-sdk";
 import type { CachedConversation } from "@xmtp/react-sdk";
 
 export const Messages: React.FC<{
   conversation: CachedConversation;
 }> = ({ conversation }) => {
-  const { error, messages, isLoading } = useMessages(conversation);
+  // error callback
+  const onError = useCallback((err: Error) => {
+    // handle error
+  }, []);
+
+  // messages callback
+  const onMessages = useCallback((msgs: DecodedMessage[]) => {
+    // do something with messages
+  }, []);
+
+  const { error, messages, isLoading } = useMessages(conversation, {
+    onError,
+    onMessages,
+  });
 
   if (error) {
     return "An error occurred while loading messages";

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -91,17 +91,10 @@ Read receipts for React Native haven't been implemented yet.
 
 ## Send a read receipt
 
-- `messageId`: ID of the message that was read
-- `timestamp`: Timestamp the read receipt sent, in ISO 8601 format
-
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-```tsx
-const readReceipt: ReadReceipt = {};
-```
-
-Once you've created a read receipt, you can send it:
+The content of a read receipt message must be an empty object.
 
 ```tsx
 await conversation.messages.send({}, ContentTypeReadReceipt);
@@ -115,9 +108,8 @@ import { useSendMessage } from "@xmtp/react-sdk";
 import { ContentTypeReadReceipt } from "@xmtp/content-type-read-receipt";
 
 const { sendMessage } = useSendMessage();
-const readReceiptContent = {};
 
-sendMessage(conversation, readReceiptContent, ContentTypeReadReceipt);
+sendMessage(conversation, {}, ContentTypeReadReceipt);
 ```
 
 </TabItem>
@@ -158,8 +150,8 @@ Here's how you can receive a read receipt:
 
 ```tsx
 if (message.contentType.sameAs(ContentTypeReadReceipt)) {
-  // We've got a reply.
-  const timestamp = message.content.timestamp;
+  // The message is a read receipt
+  const timestamp = message.sent;
 }
 ```
 
@@ -167,12 +159,14 @@ if (message.contentType.sameAs(ContentTypeReadReceipt)) {
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```jsx
+import { ContentTypeId } from "@xmtp/react-sdk";
 import { ContentTypeReadReceipt } from "@xmtp/content-type-read-receipt";
 
-if (ContentTypeReadReceipt.sameAs(message.contentType)) {
+const contentType = ContentTypeId.fromString(message.contentType);
+
+if (ContentTypeReadReceipt.sameAs(contentType)) {
   // The message is a read receipt
-  const readReceiptContent = message.content;
-  const timestamp = readReceiptContent.timestamp;
+  const timestamp = message.sentAt;
 }
 ```
 

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -103,6 +103,8 @@ await conversation.messages.send({}, ContentTypeReadReceipt);
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
+The content of a read receipt message must be an empty object.
+
 ```jsx
 import { useSendMessage } from "@xmtp/react-sdk";
 import { ContentTypeReadReceipt } from "@xmtp/content-type-read-receipt";
@@ -224,9 +226,7 @@ Read receipts for React Native haven't been implemented yet
 
 ## Use a read receipt
 
-A read receipt timestamp shouldn't be displayed. Instead, use it to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the date is lower.
-
-<!--string of the date - should be timestamp? if the string of the date/timestamp is lower than what value?-->
+A read receipt timestamp shouldn't be displayed. Instead, use it to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the timestamp is lower.
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -229,12 +229,13 @@ await conversation.send(remoteAttachment, {
 
 ```jsx
 import { useSendMessage } from "@xmtp/react-sdk";
-import { ContentTypeRemoteAttachment } from "@xmtp/content-type-remote-attachment";
+import {
+  RemoteAttachmentCodec,
+  ContentTypeRemoteAttachment,
+} from "@xmtp/content-type-remote-attachment";
 
 // Inside your component...
 const { sendMessage } = useSendMessage();
-
-import { RemoteAttachmentCodec } from "@xmtp/content-type-remote-attachment";
 
 const attachment = {
   filename: "screenshot.png",
@@ -246,7 +247,7 @@ const attachment = {
 
 const remoteAttachment = RemoteAttachmentCodec.encode(attachment);
 
-sendMessage(remoteAttachment);
+sendMessage(conversation, remoteAttachment, ContentTypeRemoteAttachment);
 ```
 
 </TabItem>

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -113,9 +113,10 @@ Once you've created a reply, you can send it. Replies are represented as objects
 ```tsx
 import { ContentTypeText } from "@xmtp/xmtp-js";
 import { ContentTypeReply } from "@xmtp/content-type-reply";
+
 const reply: Reply = {
   reference: someMessageID,
-  contentType:ContentTypeText
+  contentType: ContentTypeText
   content: "I concur",
 };
 
@@ -213,8 +214,14 @@ if (message.contentType.sameAs(ContentTypeReply)) {
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```jsx
-if (message.contentType === ContentTypeReply.toString()) {
-  const replyContent = message.content as Reply;
+import { ContentTypeId } from "@xmtp/react-sdk";
+import { ContentTypeReply } from "@xmtp/content-type-reply";
+
+const contentType = ContentTypeId.fromString(message.contentType);
+
+if (ContentTypeReply.sameAs(contentType)) {
+  // We've got a reply.
+  const reply = message.content as Reply;
   // Use reply...
 }
 ```


### PR DESCRIPTION
In this PR:

* Added options for the `useMessages` hook
* Updated read receipts docs to reflect recent change to the content type's schema
* Fixed `sendMessage` call for remote attachment content type
* Updated reply docs for more consistency with other content types