### PR TITLE
Move "Use cases" section to bottom of Documentation left nav

### DIFF
--- a/docs/concepts/_category_.json
+++ b/docs/concepts/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Concepts",
-  "position": 40,
+  "position": 30,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/interactive-tutorial.md
+++ b/docs/interactive-tutorial.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Interactive Tutorial
+sidebar_label: Interactive tutorial
 sidebar_position: 2.5
 description: Learn about the core code you need to build basic messaging with XMTP. This interactive tutorial makes real-time calls to the XMTP dev network.
 ---

--- a/docs/tutorials/_category_.json
+++ b/docs/tutorials/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Tutorials",
-  "position": 30,
+  "position": 20,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/use-cases/_category_.json
+++ b/docs/use-cases/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Use cases",
-  "position": 20,
+  "position": 40,
   "collapsible": true,
   "collapsed": false
 }


### PR DESCRIPTION
Preview: https://junk-range-possible-git-move-use-cases-xmtp-labs.vercel.app/docs/introduction

Fabri and I discussed that "Use cases" are already very accessible from the top nav. It would be great to move "Use cases" to the bottom of the left nav to allow "Tutorials" and "Concepts" to move up in the nav. This PR does that.