### PR TITLE
Update read receipt content type status and usage info

### DIFF
--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -9,15 +9,27 @@ import TabItem from "@theme/TabItem";
 
 # Support read receipts in your app built with XMTP
 
-![Status](https://img.shields.io/badge/Content_type_status-Standards--track-yellow) ![Status](https://img.shields.io/badge/Reference_implementation_status-Beta-yellow)
+![Status](https://img.shields.io/badge/Content_type_status-Standards--track-yellow) ![Status](https://img.shields.io/badge/Reference_implementation_status-Alpha-orange)
 
 Use the read receipt content type to support read receipts in your app. A read receipt is a `timestamp` that indicates when a message was read. It is sent as a message and can be used to calculate the time since the last message was read.
+
+:::important
+
+This standards-track content type is in **Alpha** status as this implementation doesn't work efficiently with the current protocol architecture. This inefficiency will be addressed in a future protocol release.
+
+Until then, if you must support read receipts, we recommend that you use this implementation and **not build your own custom content type.**
+
+:::
 
 :::tip Open for feedback
 
 You're welcome to provide feedback by commenting on the [Proposal for read receipts content type](https://github.com/orgs/xmtp/discussions/43) XIP idea.
 
 :::
+
+## Provide an opt-out option
+
+While this is a per-app decision, the best practice is to provide users with the option to opt out of sending read receipts. If a user opts out, when they read a message, a read receipt will not be sent to the sender of the message.
 
 ## Configure the read receipt content type
 
@@ -244,7 +256,15 @@ if (message.contentTypeId !== "xmtp.org/readReceipt:1.0") {
 
 ## Use a read receipt
 
-A read receipt timestamp shouldn't be displayed. Instead, use it to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the timestamp is lower.
+Generally, a read receipt indicator should be displayed under the message it's associated with. The indicator can include a timestamp. Ultimately, how you choose to display a read receipt indicator is completely up to you.
+
+:::important
+
+The read receipt is provided as an **empty message** whose timestamp provides the data needed for the indicators. **Be sure to filter out read receipt empty messages and not display them to users.**
+
+:::
+
+You can use a read receipt timestamp to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the timestamp is lower.
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>


### PR DESCRIPTION
Incremental update to guidance for read receipt content type usage based on already approved content from this merged PR: https://github.com/xmtp/xmtp-js-content-types/pull/40/files#diff-2e3b332a470b04c0ae2f86d94a52edb8d5f2ac7e346a84b44850421a502ac94c