### PR TITLE
Added Flickety check and fallback

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,13 +37,11 @@ const config = {
       src: "https://unpkg.com/flickity@2/dist/flickity.pkgd.min.js",
       defer: true,
       "data-domain": "xmtp.org",
-      crossorigin: "anonymous",
     },
     {
       src: "https://unpkg.com/flickity-fade@1/flickity-fade.js",
       defer: true,
       "data-domain": "xmtp.org",
-      crossorigin: "anonymous",
     },
   ],
   clientModules: [require.resolve("./src/css/tailwind.css")],

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -1144,10 +1144,6 @@ table code {
   text-align: center;
 }
 
-.carousel-cell img {
-  visibility: hidden;
-}
-
 .carousel-cell.is-selected img {
   visibility: visible;
 }
@@ -1155,10 +1151,6 @@ table code {
 .carousel-cell h1 {
   font-size: 48px;
   line-height: 1.1;
-}
-
-.carousel-cell h1 span {
-  opacity: 0;
 }
 
 .carousel-cell h4 {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -294,30 +294,28 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
 
   useEffect(() => {
-    var elem = document.querySelector(".main-carousel");
-    var flkty = new Flickity(elem, {
-      cellSelector: ".carousel-cell",
-      cellAlign: "center",
-      autoPlay: 5000,
-      draggable: false,
-      prevNextButtons: false,
-      pageDots: false,
-      wrapAround: true,
-      fade: true,
-      accessibility: false,
-      pauseAutoPlayOnHover: false,
-      imagesLoaded: true,
-      on: {
-        ready: function () {
-          this.off("uiChange", this.stopPlayer);
-          this.off("pointerDown", this.stopPlayer);
+    if (Flickity) {
+      var elem = document.querySelector(".main-carousel");
+      new Flickity(elem, {
+        cellSelector: ".carousel-cell",
+        cellAlign: "center",
+        autoPlay: 5000,
+        draggable: false,
+        prevNextButtons: false,
+        pageDots: false,
+        wrapAround: true,
+        fade: true,
+        accessibility: false,
+        pauseAutoPlayOnHover: false,
+        imagesLoaded: true,
+        on: {
+          ready: function () {
+            this.off("uiChange", this.stopPlayer);
+            this.off("pointerDown", this.stopPlayer);
+          },
         },
-      },
-    });
-
-    var flkty = new Flickity(".main-carousel", {});
-
-    flkty.on("select", function (index) {});
+      });
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
The Flickety carousel was hitting some race conditions when the Home component rendered before the script was finished loading. This PR adds a check to make sure the class exists before a new instance gets instantiated, and then updated some CSS so the fallback scenario looks as expected when Flickity is not defined (just stays on static image and doesn't rotate the carousel). 

While at it removed the cross-origin tags in the scripts as they are no longer needed. 