### PR TITLE
Clarify Conversation Topic V2 Format in Documentation

### DIFF
--- a/docs/concepts/architectural-overview.md
+++ b/docs/concepts/architectural-overview.md
@@ -104,7 +104,7 @@ To learn more, see [Invitations](https://github.com/xmtp/proto/blob/main/PROTOCO
 
 Clients use conversation topics to store messages exchanged between a pair of addresses.
 
-A conversation topic is created for a pair of addresses when the first message is sent between them. The conversation topic name uses this format provided by the invitation: `m-<random-32-byte-value-represented-as-a-64-character-hexadecimal-string>`
+A conversation topic is created for a pair of addresses when the first message is sent between them. The conversation topic name uses this format provided by the invitation: `m-<random-64-character-hexadecimal-string>`
 
 For example, `m-98ed4749a569d3bf302727102157361c0e513026840cbbc9be07705c5584da4d`
 


### PR DESCRIPTION
This PR updates the documentation to clarify the format of the Conversation Topic V2. Previously, the format was described as `m-<random-32-byte-alphanumeric-string>`, which could lead to confusion. 

The correct format is `m-<random-64-character-hexadecimal-string>`. 

[Preview](https://junk-range-possible-6nnafxyc6-xmtp-labs.vercel.app/docs/concepts/architectural-overview#conversation-topic-v2)
