### PR TITLE
Flutter Save Keys Snippet

### DIFF
--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -438,16 +438,13 @@ let client = try await Client.create(account: account, options: clientOptions)
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-You can configure the client environment when you call `Api.create()`.
-By default, it will connect to a `local` XMTP network.
+You can configure the client environment when you call `Api.create()`. By default, it will connect to a `local` XMTP network.
 
 ```dart
 xmtp.Api.create(host: '127.0.0.1', port: 5556, isSecure: false)
 xmtp.Api.create(host: 'dev.xmtp.network', isSecure: true)
 xmtp.Api.create(host: 'production.xmtp.network', isSecure: true)*/
 ```
-
-For important details about connecting to environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments).
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>

--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -104,24 +104,8 @@ let client = try await Client.create(
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 ```dart
-/*The client has two constructors: `createFromWallet` and `createFromKeys`.
-
-The first time a user uses a new device, they should call `createFromWallet`. This will prompt them
-to sign a message to do one of the following: Create a new identity (if they're new) or enable their existing identity (if they've used XMTP before)
-
-When this succeeds, it configures the client with a bundle of `keys` that can be stored securely on
-the device.*/
-
 var api = xmtp.Api.create();
 var client = await Client.createFromWallet(api, wallet);
-await mySecureStorage.save(client.keys.writeToBuffer());
-
-//The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.
-
-var stored = await mySecureStorage.load();
-var keys = xmtp.PrivateKeyBundle.fromBuffer(stored);
-var api = xmtp.Api.create();
-var client = await Client.createFromKeys(api, keys);
 ```
 
 </TabItem>
@@ -339,7 +323,18 @@ let client = try Client.from(bundle: keys, options: .init(api: .init(env: .produ
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample coming soon
+```dart
+var api = xmtp.Api.create();
+var client = await Client.createFromWallet(api, wallet);
+await mySecureStorage.save(client.keys.writeToBuffer());
+
+//The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.
+
+var stored = await mySecureStorage.load();
+var keys = xmtp.PrivateKeyBundle.fromBuffer(stored);
+var api = xmtp.Api.create();
+var client = await Client.createFromKeys(api, keys);
+```
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>

--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -324,10 +324,9 @@ let client = try Client.from(bundle: keys, options: .init(api: .init(env: .produ
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 ```dart
-var api = xmtp.Api.create();
+var api = xmtp.Api.create(host: 'production.xmtp.network', isSecure: true)
 var client = await Client.createFromWallet(api, wallet);
 await mySecureStorage.save(client.keys.writeToBuffer());
-
 //The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.
 
 var stored = await mySecureStorage.load();
@@ -440,8 +439,13 @@ let client = try await Client.create(account: account, options: clientOptions)
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 You can configure the client environment when you call `Api.create()`.
-
 By default, it will connect to a `local` XMTP network.
+
+```dart
+xmtp.Api.create(host: '127.0.0.1', port: 5556, isSecure: false)
+xmtp.Api.create(host: 'dev.xmtp.network', isSecure: true)
+xmtp.Api.create(host: 'production.xmtp.network', isSecure: true)*/
+```
 
 For important details about connecting to environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments).
 

--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -324,7 +324,7 @@ let client = try Client.from(bundle: keys, options: .init(api: .init(env: .produ
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
 ```dart
-var api = xmtp.Api.create(host: 'production.xmtp.network', isSecure: true)
+var api = xmtp.Api.create(host: 'dev.xmtp.network', isSecure: true)
 var client = await Client.createFromWallet(api, wallet);
 await mySecureStorage.save(client.keys.writeToBuffer());
 //The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.


### PR DESCRIPTION
Previously in the documentation snippet, the process for saving keys and creating clients was combined together. However, the saving keys snippet for the flutter tab was empty. With this update, the client creation process is now explained separately and a corresponding snippet for saving keys has been added.

Also, added in the snippet setting the `dev` network instead of the default `local`.

### Create client

```
var api = xmtp.Api.create(host: 'dev.xmtp.network', isSecure: true)
var client = await Client.createFromWallet(api, wallet);
```

### Saving keys

```
var api = xmtp.Api.create();
var client = await Client.createFromWallet(api, wallet);
await mySecureStorage.save(client.keys.writeToBuffer());

//The second time a user launches the app they should call `createFromKeys` using the stored `keys` from their previous session.

var stored = await mySecureStorage.load();
var keys = xmtp.PrivateKeyBundle.fromBuffer(stored);
var api = xmtp.Api.create();
var client = await Client.createFromKeys(api, keys);
```

- [Preview](https://junk-range-possible-git-keysflutter-xmtp-labs.vercel.app/docs/build/authentication)
