### PR TITLE
Point GH Discussions links to Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to `xmtp.org`! We're glad you're her
 
 To help ensure that your contribution experience goes as smoothly as possible, please follow the guidance provided in this document.
 
-Have a question about contributing to `xmtp.org`? Post to the [XMTP Q&A discussion forum](https://github.com/orgs/xmtp/discussions/categories/q-a).
+Have a question about contributing to `xmtp.org`? Post to the [XMTP Help & Resources forum](https://community.xmtp.org/c/help/9).
 
 ### Make a quick fix to documentation
 

--- a/blog/introducing-the-xmtp-litepaper.md
+++ b/blog/introducing-the-xmtp-litepaper.md
@@ -33,7 +33,7 @@ Over the coming weeks and months, we'll be sharing in-depth explorations of the 
 So in the meantime, while we continue to build, we invite you to:
 
 - Read the [XMTP Litepaper](https://github.com/xmtp/litepaper)
-- Discuss it with us on [𝕏](https://x.com/xmtp_), [Discord](https://discord.gg/xmtp), and [GitHub Discussions](https://github.com/orgs/xmtp/discussions)
+- Discuss it with us on [𝕏](https://x.com/xmtp_), [Discord](https://discord.gg/xmtp), and [Discourse](https://community.xmtp.org/)
 - Check out the [XMTP docs](/docs/introduction) to get started building
 
 <br/>

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -15,7 +15,7 @@ Use the reaction content type to support reactions in your app. A reaction is a 
 
 :::tip Open for feedback
 
-You're welcome to provide feedback by commenting on the [Proposal for emoji reactions content type](https://github.com/orgs/xmtp/discussions/36) XIP idea.
+You're welcome to provide feedback by commenting on the [Proposal for emoji reactions content type](https://community.xmtp.org/t/proposal-for-emoji-reactions-content-type/499/1) XIP idea.
 
 :::
 

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -319,4 +319,4 @@ function MessageContents({ content }: { content: MessageContent }) {
 How you choose to display replies in your app is up to you. It might be useful to look at the user experience for replies in popular apps such as Telegram and Discord.
 For example, in Discord, users can reply to individual messages, and the reply provides a link to the original message.
 
-Note that the user experience of replies in iMessage and Slack follows more of a threaded pattern, where messages display in logical groupings, or threads. This reply content type doesn't support the threaded pattern. If you'd like to request support for a threaded reply pattern, [post an XIP idea](https://github.com/orgs/xmtp/discussions/categories/xip-ideas).
+Note that the user experience of replies in iMessage and Slack follows more of a threaded pattern, where messages display in logical groupings, or threads. This reply content type doesn't support the threaded pattern. If you'd like to request support for a threaded reply pattern, [post an XIP idea](https://community.xmtp.org/c/development/ideas/54).

--- a/docs/concepts/content-types.md
+++ b/docs/concepts/content-types.md
@@ -134,7 +134,7 @@ Use to send a read receipt, which is a `timestamp` that indicates when a message
 Use a reaction to send a quick and often emoji-based way to respond to a message. Reactions are usually limited to a predefined set of emojis or symbols provided by the messaging app.
 
 - [Read the doc](/docs/build/messages/reaction)
-- [Comment on the XIP idea](https://community.xmtp.org/t/proposal-for-emoji-reactions-content-type/499?u=jha)
+- [Comment on the XIP idea](https://community.xmtp.org/t/proposal-for-emoji-reactions-content-type/499/1)
 - SDK support: [React](https://github.com/xmtp/xmtp-web/tree/8a248eab168eba494909d7215cffba9d50c1f87c/packages/react-sdk/src/helpers/caching/contentTypes), [JavaScript](https://github.com/xmtp/xmtp-js-content-types/tree/363e82c894f5a4436c5617b1c0424bab574b27c0/packages), [Kotlin](https://github.com/xmtp/xmtp-android/tree/main/library/src/main/java/org/xmtp/android/library/codecs), [Swift](https://github.com/xmtp/xmtp-ios/tree/main/Sources/XMTP/Codecs)
 - Implemented in: Converse
 

--- a/docs/concepts/content-types.md
+++ b/docs/concepts/content-types.md
@@ -134,7 +134,7 @@ Use to send a read receipt, which is a `timestamp` that indicates when a message
 Use a reaction to send a quick and often emoji-based way to respond to a message. Reactions are usually limited to a predefined set of emojis or symbols provided by the messaging app.
 
 - [Read the doc](/docs/build/messages/reaction)
-- [Comment on the XIP idea](https://github.com/orgs/xmtp/discussions/36)
+- [Comment on the XIP idea](https://community.xmtp.org/t/proposal-for-emoji-reactions-content-type/499?u=jha)
 - SDK support: [React](https://github.com/xmtp/xmtp-web/tree/8a248eab168eba494909d7215cffba9d50c1f87c/packages/react-sdk/src/helpers/caching/contentTypes), [JavaScript](https://github.com/xmtp/xmtp-js-content-types/tree/363e82c894f5a4436c5617b1c0424bab574b27c0/packages), [Kotlin](https://github.com/xmtp/xmtp-android/tree/main/library/src/main/java/org/xmtp/android/library/codecs), [Swift](https://github.com/xmtp/xmtp-ios/tree/main/Sources/XMTP/Codecs)
 - Implemented in: Converse
 

--- a/docs/concepts/xips.mdx
+++ b/docs/concepts/xips.mdx
@@ -10,5 +10,3 @@ An XMTP Improvement Proposal (XIP) is a design document providing information to
 We intend XIPs to be the primary mechanisms for proposing new features, collecting community technical input on an issue, and documenting the design decisions that have gone into XMTP.
 
 To learn more about XIPs and how to participate in the process, including authoring an XIP of your own, see [XIP purpose, process, and guidelines](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md).
-
-<Feedback url="https://github.com/orgs/xmtp/discussions/categories/q-a" />

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -19,11 +19,11 @@ XMTP is not accepting applications for grants at this time. Make sure to [follow
 
 Maximize your app's reach with guidance and assistance from the Partnerships team at XMTP Labs. XMTP Labs’ mission is to promote and support the development and global adoption of XMTP. [Get in touch](https://forms.gle/UMCFjB8ukiMxBxnK6)
 
-## GitHub Discussions
+## Discourse
 
-Have a question? Want to discuss an idea or protocol improvement? Start or join a discussion in the XMTP GitHub Discussions forum.
+Have a question? Want to discuss an idea or protocol improvement? Start or join a discussion in the XMTP Community Forums.
 
-[Join the discussion](https://github.com/orgs/xmtp/discussions)
+[Join the discussion](https://community.xmtp.org/)
 
 ## Discord
 
@@ -51,7 +51,7 @@ Request features by creating an issue in the [related XMTP GitHub repo](https://
 
 ### 🔀 Pull requests
 
-We encourage pull requests (PRs) from the community, but we suggest that you start with a feature request or a post to [XMTP GitHub Discussions](https://github.com/orgs/xmtp/discussions) just to do a temperature check. For example, if the PR involves a major change to the XMTP protocol, it must be fleshed out as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) before work begins.
+We encourage pull requests (PRs) from the community, but we suggest that you start with a feature request or a post to the [XMTP Community Forums](https://community.xmtp.org/) just to do a temperature check. For example, if the PR involves a major change to the XMTP protocol, it must be fleshed out as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) before work begins.
 
 If your PR to a repo in the [XMTP](https://github.com/xmtp) or [XMTP Labs](https://github.com/xmtp-labs) GitHub org is meerged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -158,7 +158,7 @@ Have you built with a tool that works well with XMTP? Let's add it to this page.
 
 The XMTP SDK is [available for multiple languages](/docs/introduction#xmtp-sdks-and-example-apps#sdks), including JavaScript, Kotlin, Swift, and Dart.
 
-Have other questions or ideas for future language or environment support? Post to the [XMTP discussion forum](https://github.com/orgs/xmtp/discussions).
+Have other questions or ideas for future language or environment support? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
 ### Which web3 libraries does the XMTP SDK require?
 
@@ -266,7 +266,7 @@ Most messaging incurs no fee. As XMTP decentralizes, messaging between participa
 
 There are no messaging-related fees incurred by developers for building with the XMTP SDK.
 
-Have other questions or ideas about message-related fees? Post to the [XMTP discussion forum](https://github.com/orgs/xmtp/discussions).
+Have other questions or ideas about message-related fees? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
 ### What are the costs of XMTP message storage and retrieval?
 
@@ -322,11 +322,11 @@ XMTP provides both `production` and `dev` network environments to support the de
 
 The `production` network is configured to store messages indefinitely.
 
-XMTP may occasionally delete messages and keys from the `dev` network and will provide advance notice in the [XMTP Discord community](https://discord.gg/xmtp) and [XMTP Announcements discussion forum](https://github.com/orgs/xmtp/discussions/categories/announcements).
+XMTP may occasionally delete messages and keys from the `dev` network and will provide advance notice in the [XMTP Discord community](https://discord.gg/xmtp) and [XMTP Announcements forum](https://community.xmtp.org/c/start-here/announcements/7).
 
 Different approaches to long-term message storage are currently being researched.
 
-Have other questions or ideas about message storage? Post to the [XMTP discussion forum](https://github.com/orgs/xmtp/discussions).
+Have other questions or ideas about message storage? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
 ## Messages
 
@@ -346,7 +346,7 @@ To learn more about content types, see [Content types](/docs/concepts/content-ty
 
 To learn more about the XMTP improvement proposals governance process, see [What is an XIP?](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md)
 
-Have other questions or ideas about message formats and metadata? Post to the [XMTP discussion forum](https://github.com/orgs/xmtp/discussions).
+Have other questions or ideas about message formats and metadata? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
 ### Does XMTP support message attachments?
 
@@ -365,7 +365,7 @@ To learn more about how to implement message attachments in your app, see:
 
 Not currently. However, XMTP Labs is exploring ways to support message deletion and editing.
 
-Have other questions or ideas about support for message deletion and editing? Post to the [XMTP discussion forum](https://github.com/orgs/xmtp/discussions).
+Have other questions or ideas about support for message deletion and editing? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
 ## Message patterns
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -381,12 +381,12 @@ const config = {
                 href: "https://discord.gg/xmtp",
               },
               {
-                label: "𝕏",
-                href: "https://x.com/xmtp_",
+                label: "Community forums",
+                href: "https://community.xmtp.org/",
               },
               {
-                label: "GitHub Discussions",
-                href: "https://github.com/orgs/xmtp/discussions",
+                label: "𝕏",
+                href: "https://x.com/xmtp_",
               },
               {
                 label: "GitHub",

--- a/src/components/Feedback/index.js
+++ b/src/components/Feedback/index.js
@@ -4,7 +4,7 @@ import ALink from "../ALink";
 const Feedback = ({ url }) => {
   return (
     <ALink
-      to="https://github.com/orgs/xmtp/discussions/categories/q-a"
+      to="https://community.xmtp.org/c/help/9"
       className="grid grid-flow-col items-center text-red-500 text-sm font-semibold ml-1.5 justify-start border-0 border-t border-solid border-black dark:border-neutral-500 pt-4 toc-footer"
     >
       <img src="/img/question-icon.svg" className="mr-1.5" />

--- a/src/components/MainContent/index.js
+++ b/src/components/MainContent/index.js
@@ -120,7 +120,7 @@ export const MainContent = ({ styles }) => {
 
                   <span className="text-base text-neutral-800 dark:text-neutral-300 color-neutral-300">
                     <ALink
-                      to="https://github.com/orgs/xmtp/discussions"
+                      to="https://community.xmtp.org/"
                       className="text-red-500 font-bold">
                       Join the discussion
                     </ALink>

--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -14,7 +14,7 @@ The site uses Plausible analytics for the sole purpose of helping site contribut
 
 To learn more about the data Plausible tracks, see the [Plausible Data Policy](https://plausible.io/data-policy).
 
-If you have any questions about this privacy policy, post to the [XMTP Q&A discussion forum](https://github.com/orgs/xmtp/discussions/categories/q-a).
+If you have any questions about this privacy policy, post to the [XMTP Help & Resources forum](https://community.xmtp.org/c/help/9).
 
 <br/>
 <FeedbackWidget />

--- a/src/pages/start-building.md
+++ b/src/pages/start-building.md
@@ -40,7 +40,7 @@ Ask questions and learn with others building with XMTP. Join the community on th
 
 - Discord: [Chat with other builders](https://discord.gg/xmtp)
 - 𝕏: [Follow @XMTP\_](https://x.com/xmtp_)
-- GitHub Discussions: [Join the discussion](https://github.com/orgs/xmtp/discussions)
+- Discourse: [Join the discussion](https://community.xmtp.org/)
 
 ## Contribute to XMTP
 

--- a/src/pages/terms.mdx
+++ b/src/pages/terms.mdx
@@ -19,7 +19,7 @@ This means that except as otherwise noted, page content is licensed under the [C
 
 When you see a page with this notice, you are free to use [nearly everything](#what-is-not-licensed) on the page in your own creations. For example, you could quote the text in a book, cut-and-paste sections to your blog, record it as an audiobook for the visually impaired, or even translate it into Swahili. Really. That's what open content licenses are all about. We just ask that you give us [attribution](#attribution) when you reuse our work.
 
-If you have any questions about these terms of service, post to the [XMTP Q&A discussion forum](https://github.com/orgs/xmtp/discussions/categories/q-a).
+If you have any questions about these terms of service, post to the [XMTP Help & Resources forum](https://community.xmtp.org/c/help/9).
 
 ## What is _not_ licensed?
 


### PR DESCRIPTION
Some GH Discussions links remain because they point to active discussions that haven't been migrated yet. Will update links once migration is complete.