### PR TITLE
React Native Content Type Updates

### DIFF
--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -400,7 +400,15 @@ Code sample coming soon
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-Code sample coming soon
+```jsx
+if(/*Not supported content type*/){
+  return message?.fallback ? (
+    message?.fallback
+  ) : (
+    <div style={styles.RenderedMessage}>"Message not supported"</div>
+  );
+}
+```
 
 </TabItem>
 </Tabs >

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -98,7 +98,12 @@ var registry = CodecRegistry()..registerCodec(ReactionCodec());
 
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-React Native SDK already has the codecs registered.
+```jsx
+const client = await Client.create(wallet, {
+  env: "production",
+  codecs: [new XMTP.ReactionCodec()],
+});
+```
 
 </TabItem>
 </Tabs>
@@ -295,18 +300,8 @@ var decoded = await codec.decode(encoded);
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-function MessageContents({ content }: { content: MessageContent }) {
-  if (content.reaction) {
-    // This is a reaction
-    const reactionContent = content.reaction.content;
-    const messageId = content.reaction.reference;
-    const action = content.reaction.action;
-    const schema = content.reaction.schema;
-
-    // Handle the reaction content, the referenced message ID, the action, and the schema
-    // ...
-  }
-  // ...
+if (message.contentTypeId === "xmtp.org/reaction:1.0") {
+  return message.content;
 }
 ```
 

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -99,9 +99,9 @@ var registry = CodecRegistry()..registerCodec(ReactionCodec());
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-const client = await Client.create(wallet, {
+const client = await Client.create(signer, {
   env: "production",
-  codecs: [new XMTP.ReactionCodec()],
+  codecs: [new ReactionCodec()],
 });
 ```
 

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -301,7 +301,12 @@ var decoded = await codec.decode(encoded);
 
 ```jsx
 if (message.contentTypeId === "xmtp.org/reaction:1.0") {
-  return message.content;
+  const reaction = await message.content();
+  return reaction;
+  //reaction.reference = id of the message being reacted to,
+  //reaction.action = 'added',
+  //reaction.schema =  'unicode',
+  //reaction.content = '💖',
 }
 ```
 

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -99,7 +99,12 @@ Read receipts for Dart haven't been implemented yet.
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-React Native SDK already has the codecs registered.
+```jsx
+const client = await Client.create(wallet, {
+  env: "production",
+  codecs: [new XMTP.ReadReceiptCodec()],
+});
+```
 
 </TabItem></Tabs>
 
@@ -246,8 +251,8 @@ Read receipts for Dart haven't been implemented yet
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-if (message.contentTypeId !== "xmtp.org/readReceipt:1.0") {
-  throw Error("Unexpected message content " + bobMessages[0].content);
+if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
+  return content.timestamp; //Date received
 }
 ```
 

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -252,7 +252,7 @@ Read receipts for Dart haven't been implemented yet
 
 ```jsx
 if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
-  return content.timestamp; //Date received
+  return message.content().timestamp; //Date received
 }
 ```
 

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -100,9 +100,9 @@ Read receipts for Dart haven't been implemented yet.
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-const client = await Client.create(wallet, {
+const client = await Client.create(signer, {
   env: "production",
-  codecs: [new XMTP.ReadReceiptCodec()],
+  codecs: [new ReadReceiptCodec()],
 });
 ```
 
@@ -252,7 +252,7 @@ Read receipts for Dart haven't been implemented yet
 
 ```jsx
 if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
-  return message.content().timestamp; //Date received
+  return message.sent; //Date received
 }
 ```
 

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -622,10 +622,15 @@ On the receiving end, you can use the `decryptAttachment` method to decrypt the 
 
 ```jsx
 if (message.contentTypeId === "xmtp.org/remoteStaticAttachment:1.0") {
-  const attached = await alice.decryptAttachment({
+  // Now we can decrypt the downloaded file using the message metadata.
+  const attached = await xmtp_client.decryptAttachment({
     encryptedLocalFileUri: downloadedFileUri,
-    metadata: message.content.remoteAttachment,
-  });
+    metadata: message.content() as RemoteAttachmentContent,
+  })
+
+  //attached.filename
+  //attached.mimeType
+  //attached.fileUri
 }
 ```
 

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -100,9 +100,9 @@ Remote attachments for Dart haven't been implemented yet.
 <TabItem value="rn" label="React Native" attributes={{className: "rn_tab"}}>
 
 ```jsx
-const client = await Client.create(wallet, {
+const client = await Client.create(signer, {
   env: "production",
-  codecs: [new XMTP.RemoteAttachmentCodec(), new XMTP.StaticAttachmentCodec()],
+  codecs: [new RemoteAttachmentCodec(), new StaticAttachmentCodec()],
 });
 ```
 

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -99,9 +99,12 @@ Remote attachments for Dart haven't been implemented yet.
 </TabItem>
 <TabItem value="rn" label="React Native" attributes={{className: "rn_tab"}}>
 
-The XMTP SDK handles the registration of codecs for you. When you use the SDK's functions like `encryptAttachment` and `decryptAttachment`, the SDK internally uses the appropriate codecs to perform the encryption and decryption operations.
-
-You don't need to manually register or use the codecs in your app code. You just need to work with the high-level objects and methods provided by the SDK.
+```jsx
+const client = await Client.create(wallet, {
+  env: "production",
+  codecs: [new XMTP.RemoteAttachmentCodec(), new XMTP.StaticAttachmentCodec()],
+});
+```
 
 </TabItem>
 </Tabs>

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -303,7 +303,7 @@ if (decodedContent.contentType == contentTypeReply) {
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-if (message.contentTypeId === "xmtp.org/reaction:1.0") {
+if (message.contentTypeId === "xmtp.org/reply:1.0") {
   const reply = message.content();
   if (reply) {
     const replyContent: ReplyContent = reply;

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -304,15 +304,11 @@ if (decodedContent.contentType == contentTypeReply) {
 
 ```jsx
 if (message.contentTypeId === "xmtp.org/reaction:1.0") {
-  if (message.content.reply) {
-    // This is a reply
-    const replyContent = content.reply.content;
-    const messageId = content.reply.reference;
-
-    // Handle the reply content and the referenced message ID
-    // ...
+  const reply = message.content();
+  if (reply) {
+    const replyContent = reply.content;
+    const messageId = reply.reference;
   }
-  // ...
 }
 ```
 

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -97,7 +97,7 @@ var registry = CodecRegistry()..registerCodec(ReplyCodec());
 ```jsx
 const client = await Client.create(wallet, {
   env: "production",
-  codecs: [new XMTP.ReplyCodec()],
+  codecs: [new ReplyCodec()],
 });
 ```
 
@@ -306,8 +306,10 @@ if (decodedContent.contentType == contentTypeReply) {
 if (message.contentTypeId === "xmtp.org/reaction:1.0") {
   const reply = message.content();
   if (reply) {
-    const replyContent = reply.content;
-    const messageId = reply.reference;
+    const replyContent: ReplyContent = reply;
+    const replyContentType = replyContent.contentType;
+    const codec = client.codecRegistry[replyContentType];
+    const actualReplyContent = codec.decode(replyContent.content);
   }
 }
 ```
@@ -321,7 +323,3 @@ How you choose to display replies in your app is up to you. It might be useful t
 For example, in Discord, users can reply to individual messages, and the reply provides a link to the original message.
 
 Note that the user experience of replies in iMessage and Slack follows more of a threaded pattern, where messages display in logical groupings, or threads. This reply content type doesn't support the threaded pattern. If you'd like to request support for a threaded reply pattern, [post an XIP idea](https://community.xmtp.org/c/development/ideas/54).
-
-```
-
-```

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -94,7 +94,12 @@ var registry = CodecRegistry()..registerCodec(ReplyCodec());
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
-The React Native SDK already has the codecs registered.
+```jsx
+const client = await Client.create(wallet, {
+  env: "production",
+  codecs: [new XMTP.ReplyCodec()],
+});
+```
 
 </TabItem>
 </Tabs>
@@ -298,8 +303,8 @@ if (decodedContent.contentType == contentTypeReply) {
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-function MessageContents({ content }: { content: MessageContent }) {
-  if (content.reply) {
+if (message.contentTypeId === "xmtp.org/reaction:1.0") {
+  if (message.content.reply) {
     // This is a reply
     const replyContent = content.reply.content;
     const messageId = content.reply.reference;
@@ -320,3 +325,7 @@ How you choose to display replies in your app is up to you. It might be useful t
 For example, in Discord, users can reply to individual messages, and the reply provides a link to the original message.
 
 Note that the user experience of replies in iMessage and Slack follows more of a threaded pattern, where messages display in logical groupings, or threads. This reply content type doesn't support the threaded pattern. If you'd like to request support for a threaded reply pattern, [post an XIP idea](https://community.xmtp.org/c/development/ideas/54).
+
+```
+
+```

--- a/docs/tutorials/custom-ct.mdx
+++ b/docs/tutorials/custom-ct.mdx
@@ -13,8 +13,6 @@ Building a custom content type enables you to manage data in a way that is more 
 
 For more common content types, you can usually find a [standard](/docs/concepts/content-types#standard-content-types) or [standards-track](/docs/concepts/content-types#standards-track-content-types) content type to serve your needs.
 
-If another developer wants to display your custom content type in their app, they must implement it exactly as you've defined it in your code.
-
 If your custom content type generates interest within the developer community, consider proposing it as a standard content type through the [XIP process](/docs/concepts/xips).
 
 This tutorial covers how to build two example custom content types:

--- a/docs/tutorials/custom-ct.mdx
+++ b/docs/tutorials/custom-ct.mdx
@@ -2,7 +2,6 @@
 sidebar_label: Custom content type
 sidebar_position: 10
 description: Learn how to build custom content types for use with XMTP
-
 ---
 
 import Tabs from "@theme/Tabs";
@@ -10,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 # Build custom content types for use with XMTP
 
-Building a custom content type enables you to manage data in a way that is more personalized or specialized to the needs of your app. 
+Building a custom content type enables you to manage data in a way that is more personalized or specialized to the needs of your app.
 
 For more common content types, you can usually find a [standard](/docs/concepts/content-types#standard-content-types) or [standards-track](/docs/concepts/content-types#standards-track-content-types) content type to serve your needs.
 
@@ -28,94 +27,157 @@ This tutorial covers how to build two example custom content types:
 
 Build a custom content type to multiply numbers.
 
-1. Create the custom content type by creating a new file, `xmtp-content-type-multiply-number.tsx`. This file hosts the `MultiplyCodec` class for encoding and decoding the custom content type.
+1. Create the custom content type by creating a new file
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    import { ContentTypeId } from "@xmtp/xmtp-js";
+```jsx
+import { ContentTypeId } from "@xmtp/xmtp-js";
 
-    // Create a unique identifier for your content type
-    const ContentTypeMultiplyNumbers = new ContentTypeId({
-      authorityId: "your.domain",
-      typeId: "multiply-number",
-      versionMajor: 1,
-      versionMinor: 0,
-    });
+// Create a unique identifier for your content type
+const ContentTypeMultiplyNumbers = new ContentTypeId({
+  authorityId: "your.domain",
+  typeId: "multiply-number",
+  versionMajor: 1,
+  versionMinor: 0,
+});
 
-    // Define the MultiplyCodec class
-    class ContentTypeMultiplyNumberCodec {
-      get contentType() {
-        return ContentTypeMultiplyNumbers;
-      }
+// Define the MultiplyCodec class
+class ContentTypeMultiplyNumberCodec {
+  get contentType() {
+    return ContentTypeMultiplyNumbers;
+  }
 
-      // The encode method accepts an object with two numbers (a, b) and encodes it as a byte array
-      encode({ a, b }) {
-        return {
-          type: ContentTypeMultiplyNumbers,
-          parameters: {},
-          content: new TextEncoder().encode(JSON.stringify({ a, b })),
-        };
-      }
+  // The encode method accepts an object with two numbers (a, b) and encodes it as a byte array
+  encode({ a, b }) {
+    return {
+      type: ContentTypeMultiplyNumbers,
+      parameters: {},
+      content: new TextEncoder().encode(JSON.stringify({ a, b })),
+    };
+  }
 
-      // The decode method decodes the byte array, parses the string into numbers (a, b), and returns their product
-      decode(content: { content: any }) {
-        const uint8Array = content.content;
-        const { a, b } = JSON.parse(new TextDecoder().decode(uint8Array));
-        return a * b;
-      }
+  // The decode method decodes the byte array, parses the string into numbers (a, b), and returns their product
+  decode(content: { content: any }) {
+    const uint8Array = content.content;
+    const { a, b } = JSON.parse(new TextDecoder().decode(uint8Array));
+    return a * b;
+  }
+}
+```
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+```jsx
+const ContentTypeNumber: ContentTypeId = {
+  authorityId: 'yourdomain.org',
+  typeId: 'number',
+  versionMajor: 1,
+  versionMinor: 0,
+}
+
+class NumberCodec implements JSContentCodec<number> {
+  contentType = ContentTypeNumber
+
+  // a completely absurd way of encoding number values
+  encode(content: number): EncodedContent {
+    return {
+      type: ContentTypeNumber,
+      parameters: {
+        number: JSON.stringify(content),
+      },
+      content: new Uint8Array(),
     }
-    ```
+  }
+  decode(encodedContent: EncodedContent): number {
+    return JSON.parse(encodedContent.parameters.number) as number
+  }
 
-    </TabItem></Tabs>
+  fallback(content: number): string | undefined {
+    return 'A number was sent.'
+  }
+}
+```
+
+</TabItem>
+</Tabs>
 
 2. Import and register the custom content type.
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    import {
-      ContentTypeMultiplyNumber,
-      ContentTypeMultiplyNumberCodec,
-    } from "./xmtp-content-type-multiply-number";
+```jsx
+import { ContentTypeMultiplyNumberCodec } from "./xmtp-content-type-multiply-number";
 
-    const xmtp = await Client.create(wallet, {
-      env: "dev",
-    });
-    xmtp.registerCodec(new ContentTypeMultiplyNumberCodec());
-    ```
+const xmtp = await Client.create(wallet, {
+  env: "dev",
+});
+xmtp.registerCodec(new ContentTypeMultiplyNumberCodec());
+```
 
-    </TabItem></Tabs>
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+```jsx
+import { NumberCodec } from "./xmtp-content-type-number";
+
+const client = await Client.create({
+  env: "production",
+  codecs: [new NumberCodec()],
+});
+```
+
+</TabItem>
+</Tabs>
 
 3. Send a message using the custom content type. This code sample demonstrates how to use the `MultiplyCodec` custom content type to perform multiplication operations.
 
-  <Tabs groupId="sdk-langs">
-  <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-  ```jsx
-  const numbersToMultiply = { a: 3, b: 7 };
+```jsx
+const numbersToMultiply = { a: 3, b: 7 };
 
-  conversation.send(numbersToMultiply, {
-    contentType: ContentTypeMultiplyNumbers,
-  });
-  ```
+conversation.send(numbersToMultiply, {
+  contentType: ContentTypeMultiplyNumbers,
+});
+```
 
-  </TabItem></Tabs>
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+```jsx
+await conversation.send(12, { contentType: ContentTypeNumber });
+```
+
+</TabItem>
+</Tabs>
 
 4. To use the result of the multiplication operation, add a renderer for the custom content type.
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    if (message.contentType.sameAs(ContentTypeMultiplyNumber)) {
-      return message.content; // 21
-    }
-    ```
+```jsx
+if (message.contentType.sameAs(ContentTypeMultiplyNumber)) {
+  return message.content; // 21
+}
+```
 
-    </TabItem></Tabs>
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+```jsx
+if (message.contentTypeId === "yourdomain.org/number:1.0") {
+  return message.content; // 12
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## Advanced: Send token transaction hashes
 
@@ -123,154 +185,154 @@ Build a custom content type to send transaction hashes on the Polygon blockchain
 
 1. Create the custom content type by creating a new file, `xmtp-content-type-transaction-hash.tsx`. This file hosts the `TransactionHash` class for encoding and decoding the custom content type.
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    import { ContentTypeId } from "@xmtp/xmtp-js";
+```jsx
+import { ContentTypeId } from "@xmtp/xmtp-js";
 
-    export const ContentTypeTransactionHash = new ContentTypeId({
-      authorityId: "your.domain",
-      typeId: "transaction-hash",
-      versionMajor: 1,
-      versionMinor: 0,
-    });
+export const ContentTypeTransactionHash = new ContentTypeId({
+  authorityId: "your.domain",
+  typeId: "transaction-hash",
+  versionMajor: 1,
+  versionMinor: 0,
+});
 
-    export class ContentTypeTransactionHashCodec {
-      get contentType() {
-        return ContentTypeTransactionHash;
-      }
+export class ContentTypeTransactionHashCodec {
+  get contentType() {
+    return ContentTypeTransactionHash;
+  }
 
-      encode(hash) {
-        return {
-          type: ContentTypeTransactionHash,
-          parameters: {},
-          content: new TextEncoder().encode(hash),
-        };
-      }
+  encode(hash) {
+    return {
+      type: ContentTypeTransactionHash,
+      parameters: {},
+      content: new TextEncoder().encode(hash),
+    };
+  }
 
-      decode(content: { content: any }) {
-        const uint8Array = content.content;
-        const hash = new TextDecoder().decode(uint8Array);
-        return hash;
-      }
-    }
-    ```
+  decode(content: { content: any }) {
+    const uint8Array = content.content;
+    const hash = new TextDecoder().decode(uint8Array);
+    return hash;
+  }
+}
+```
 
-    </TabItem></Tabs>
+</TabItem></Tabs>
 
 2. Import and register the custom content type.
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    import {
-      ContentTypeTransactionHash,
-      ContentTypeTransactionHashCodec,
-    } from "./xmtp-content-type-transaction-hash";
+```jsx
+import {
+  ContentTypeTransactionHash,
+  ContentTypeTransactionHashCodec,
+} from "./xmtp-content-type-transaction-hash";
 
-    const xmtp = await Client.create(wallet, {
-      env: "dev",
-    });
-    xmtp.registerCodec(new ContentTypeTransactionHashCodec());
-    ```
+const xmtp = await Client.create(wallet, {
+  env: "dev",
+});
+xmtp.registerCodec(new ContentTypeTransactionHashCodec());
+```
 
-    </TabItem></Tabs>
+</TabItem></Tabs>
 
 3. Send a message using the custom content type. This code sample demonstrates how to use the `TransactionHash` content type to send a transaction.
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    // Create a wallet from a known private key
-    const wallet = new ethers.Wallet(privateKey);
-    console.log(`Wallet address: ${wallet.address}`);
+```jsx
+// Create a wallet from a known private key
+const wallet = new ethers.Wallet(privateKey);
+console.log(`Wallet address: ${wallet.address}`);
 
-    //im using a burner wallet with MATIC from a faucet
-    //https://faucet.polygon.technology/
+//im using a burner wallet with MATIC from a faucet
+//https://faucet.polygon.technology/
 
-    // Set up provider for Polygon Testnet (Mumbai)
-    const provider = new ethers.providers.JsonRpcProvider(
-      "https://rpc-mumbai.maticvigil.com",
-    );
+// Set up provider for Polygon Testnet (Mumbai)
+const provider = new ethers.providers.JsonRpcProvider(
+  "https://rpc-mumbai.maticvigil.com",
+);
 
-    // Connect the wallet to the provider
-    const signer = wallet.connect(provider);
+// Connect the wallet to the provider
+const signer = wallet.connect(provider);
 
-    // Define the recipient address and amount
-    const amount = ethers.utils.parseEther("0.01"); // Amount in ETH (0.01 in this case)
+// Define the recipient address and amount
+const amount = ethers.utils.parseEther("0.01"); // Amount in ETH (0.01 in this case)
 
-    // Create a transaction
-    const transaction = {
-      to: recipientAddress,
-      value: amount,
-    };
+// Create a transaction
+const transaction = {
+  to: recipientAddress,
+  value: amount,
+};
 
-    // Sign and send the transaction
-    const tx = await signer.sendTransaction(transaction);
-    console.log(`Transaction hash: ${tx.hash}`);
+// Sign and send the transaction
+const tx = await signer.sendTransaction(transaction);
+console.log(`Transaction hash: ${tx.hash}`);
 
-    const conversation = await xmtp.conversations.newConversation(WALLET_TO);
-    await conversation
-      .send(tx.hash, {
-        contentType: ContentTypeTransactionHash,
-      })
-      .then(() => {
-        console.log("Transaction data sent", tx.hash);
-      })
-      .catch((error) => {
-        console.log("Error sending transaction data: ", error);
-      });
-    ```
+const conversation = await xmtp.conversations.newConversation(WALLET_TO);
+await conversation
+  .send(tx.hash, {
+    contentType: ContentTypeTransactionHash,
+  })
+  .then(() => {
+    console.log("Transaction data sent", tx.hash);
+  })
+  .catch((error) => {
+    console.log("Error sending transaction data: ", error);
+  });
+```
 
-    </TabItem></Tabs>
+</TabItem></Tabs>
 
 4. To use the result of the hash, add an async renderer for the custom content type.
 
-    <Tabs groupId="sdk-langs">
-    <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-    ```jsx
-    if (message.contentType.sameAs(ContentTypeTransactionHash)) {
-      // Handle ContentTypeAttachment
-      return (
-        <TransactionMonitor key={message.id} encodedContent={message.content} />
+```jsx
+if (message.contentType.sameAs(ContentTypeTransactionHash)) {
+  // Handle ContentTypeAttachment
+  return (
+    <TransactionMonitor key={message.id} encodedContent={message.content} />
+  );
+}
+
+const TransactionMonitor = ({ encodedContent }) => {
+  const [retryCount, setRetryCount] = useState(0);
+
+  const [transactionValue, setTransactionValue] = useState(null);
+
+  useEffect(() => {
+    const fetchTransactionReceipt = async () => {
+      console.log(encodedContent);
+      const provider = new ethers.providers.JsonRpcProvider(
+        "https://rpc-mumbai.maticvigil.com",
       );
-    }
-
-    const TransactionMonitor = ({ encodedContent }) => {
-      const [retryCount, setRetryCount] = useState(0);
-
-      const [transactionValue, setTransactionValue] = useState(null);
-
-      useEffect(() => {
-        const fetchTransactionReceipt = async () => {
-          console.log(encodedContent);
-          const provider = new ethers.providers.JsonRpcProvider(
-            "https://rpc-mumbai.maticvigil.com",
-          );
-          const receipt = await provider.getTransactionReceipt(encodedContent);
-          const tx = await provider.getTransaction(encodedContent);
-          if (tx && tx.value) {
-            setTransactionValue(ethers.utils.formatEther(tx.value));
-          }
-        };
-        fetchTransactionReceipt();
-      }, [encodedContent, retryCount]);
-
-      return transactionValue ? (
-        <div>Transaction value: {transactionValue} ETH</div>
-      ) : (
-        <div>
-          Waiting for transaction to be mined...
-          <button onClick={() => setRetryCount(retryCount + 1)}>
-            Refresh Status 🔄
-          </button>
-        </div>
-      );
+      const receipt = await provider.getTransactionReceipt(encodedContent);
+      const tx = await provider.getTransaction(encodedContent);
+      if (tx && tx.value) {
+        setTransactionValue(ethers.utils.formatEther(tx.value));
+      }
     };
-    ```
+    fetchTransactionReceipt();
+  }, [encodedContent, retryCount]);
 
-    </TabItem></Tabs>
+  return transactionValue ? (
+    <div>Transaction value: {transactionValue} ETH</div>
+  ) : (
+    <div>
+      Waiting for transaction to be mined...
+      <button onClick={() => setRetryCount(retryCount + 1)}>
+        Refresh Status 🔄
+      </button>
+    </div>
+  );
+};
+```
+
+</TabItem></Tabs>

--- a/docs/tutorials/custom-ct.mdx
+++ b/docs/tutorials/custom-ct.mdx
@@ -168,9 +168,11 @@ if (message.contentType.sameAs(ContentTypeMultiplyNumber)) {
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
+Because of this message content is now a function which returns the actual content. You can get that content by call `message.content()` now instead of message.content . This may involve more filtering on the message side to make sure you are handling different contentTypes appropriately.
+
 ```jsx
 if (message.contentTypeId === "yourdomain.org/number:1.0") {
-  return message.content; // 12
+  return message.content(); // 12
 }
 ```
 


### PR DESCRIPTION
This PR updates documentation related to content types based on the release [v1.21.0](https://github.com/xmtp/xmtp-react-native/releases/tag/v1.21.0) of the RN SDK

### Breaking change
XMTP used to register supported codecs for you by default. Now you must register all codecs you’d like to support manually on client create

- [RemoteAttachments](https://junk-range-possible-git-rnct-xmtp-labs.vercel.app/docs/build/messages/remote-attachment)
- [Reply](https://junk-range-possible-git-rnct-xmtp-labs.vercel.app/docs/build/messages/reply)
- [ReadReceipt](https://junk-range-possible-git-rnct-xmtp-labs.vercel.app/docs/build/messages/read-receipt)
- [Reaction](https://junk-range-possible-git-rnct-xmtp-labs.vercel.app/docs/build/messages/reaction)

### Custom content types
React Native now supports custom codecs, enabling you to send any type of content that makes sense for you and your app. We've added a new RN tab on the tutorial.

- [Custom CT Tutorial](https://junk-range-possible-git-rnct-xmtp-labs.vercel.app/docs/tutorials/custom-ct)

### Message Content
Because of this message content is now a function which returns the actual content. You can get that content by call `message.content()` now instead of `message.content`. This may involve more filtering on the message side to make sure you are handling different contentTypes appropriately.

