### PR TITLE
Updated `Signer` references

### DIFF
--- a/docs/build/authentication.md
+++ b/docs/build/authentication.md
@@ -25,7 +25,7 @@ A client is created that requires passing in a connected wallet that implements 
 ```ts
 import { Client } from "@xmtp/xmtp-js";
 // Create the client with a `Signer` from your application
-const xmtp = await Client.create(wallet, { env: "dev" });
+const xmtp = await Client.create(signer, { env: "dev" });
 ```
 
 </TabItem>
@@ -114,7 +114,7 @@ var client = await Client.createFromWallet(api, wallet);
 ```tsx
 import { Client } from "@xmtp/xmtp-react-native";
 // Create the client with a `Signer` from your application
-const xmtp = await Client.create(wallet);
+const xmtp = await Client.create(signer);
 ```
 
 </TabItem>

--- a/docs/build/conversations.md
+++ b/docs/build/conversations.md
@@ -332,7 +332,7 @@ To disable this behavior, set the `persistConversations` client option to `false
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
 ```ts
-const clientWithNoCache = await Client.create(wallet, {
+const clientWithNoCache = await Client.create(signer, {
   persistConversations: false,
 });
 ```
@@ -352,12 +352,12 @@ await initialize({ signer, options });
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
-val client = Client().create(wallet, { env: "dev" })
+val client = Client().create(signer, { env: "dev" })
 val conversations = client.conversations.export()
 saveConversationsSomewhere(JSON.stringify(conversations))
 // To load the conversations in a new SDK instance you can run:
 
-val client = Client.create(wallet, { env: "dev" })
+val client = Client.create(signer, { env: "dev" })
 val conversations = JSON.parse(loadConversationsFromSomewhere())
 val client.importConversation(conversations)
 ```

--- a/docs/build/get-started/overview.md
+++ b/docs/build/get-started/overview.md
@@ -27,9 +27,9 @@ import { Client } from "@xmtp/xmtp-js";
 import { Wallet } from "ethers";
 
 // You'll want to replace this with a wallet from your application
-const wallet = Wallet.createRandom();
+const signer = Wallet.createRandom();
 // Create the client with your wallet. This will connect to the XMTP development network by default
-const xmtp = await Client.create(wallet, { env: "dev" });
+const xmtp = await Client.create(signer, { env: "dev" });
 // Start a conversation with XMTP
 const conversation = await xmtp.conversations.newConversation(
   "0x3F11b27F323b62B159D2642964fa27C46C841897",

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -95,7 +95,7 @@ var registry = CodecRegistry()..registerCodec(ReplyCodec());
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-const client = await Client.create(wallet, {
+const client = await Client.create(signer, {
   env: "production",
   codecs: [new ReplyCodec()],
 });

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -47,7 +47,7 @@ console.log("Wallet address: " + wallet.address);
 A client is created that requires passing in a connected wallet that implements the Signer interface. Use client configuration options to change parameters of a client's network connection.
 
 ```jsx
-const xmtp = await Client.create(wallet, { env: "dev" });
+const xmtp = await Client.create(signer, { env: "dev" });
 console.log("Client created", xmtp.address);
 //eg. Client created 0xd8dA6BF26964aF9D7eEd9e03E53415D37
 ```

--- a/docs/tutorials/broadcast.md
+++ b/docs/tutorials/broadcast.md
@@ -24,9 +24,9 @@ const { Client } = require("@xmtp/xmtp-js");
 
 async function main() {
   //Create a random wallet for example purposes. On the frontend you should replace it with the user's wallet (metamask, rainbow, etc)
-  const wallet = ethers.Wallet.createRandom();
+  const signer = ethers.Wallet.createRandom();
   //Initialize the xmtp client
-  const xmtp = await Client.create(wallet, { env: "dev" });
+  const xmtp = await Client.create(signer, { env: "dev" });
   console.log("Broadcasting from: ", xmtp.address);
 
   //In this example we are going to broadcast to the GM_BOT wallet (already activated) and a random wallet (not activated)
@@ -40,7 +40,6 @@ async function main() {
     //Checking the activation status of each wallet
     const wallet = broadcasts_array[i];
     const canMessage = broadcasts_canMessage[i];
-    console.log(wallet, canMessage);
     if (broadcasts_canMessage[i]) {
       //If activated, start
       const conversation = await xmtp.conversations.newConversation(wallet);

--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -270,4 +270,4 @@ All the examples thus far have been using a randomly generated wallet and a priv
 
 With a simple web page that uses Wagmi, Web3Modal, or any other library that returns an `ethers.Signer`, you can export XMTP-specific keys and store those on the user's machine.
 
-The command to export keys is `Client.getKeys(wallet, { env })`.
+The command to export keys is `Client.getKeys(signer, { env })`.

--- a/docs/tutorials/custom-ct.mdx
+++ b/docs/tutorials/custom-ct.mdx
@@ -110,7 +110,7 @@ class NumberCodec implements JSContentCodec<number> {
 ```jsx
 import { ContentTypeMultiplyNumberCodec } from "./xmtp-content-type-multiply-number";
 
-const xmtp = await Client.create(wallet, {
+const xmtp = await Client.create(signer, {
   env: "dev",
 });
 xmtp.registerCodec(new ContentTypeMultiplyNumberCodec());
@@ -232,7 +232,7 @@ import {
   ContentTypeTransactionHashCodec,
 } from "./xmtp-content-type-transaction-hash";
 
-const xmtp = await Client.create(wallet, {
+const xmtp = await Client.create(signer, {
   env: "dev",
 });
 xmtp.registerCodec(new ContentTypeTransactionHashCodec());

--- a/src/components/FeedbackWidget/utils.js
+++ b/src/components/FeedbackWidget/utils.js
@@ -17,8 +17,8 @@ export const options = [
  * Sends the feedback message in the correct shape to the appropriate wallet.
  */
 export async function reportFeedback(helpful, reason, extraInfo) {
-  const wallet = Wallet.createRandom();
-  const client = await Client.create(wallet, { env: "dev" });
+  const signer = Wallet.createRandom();
+  const client = await Client.create(signer, { env: "dev" });
   await client.publishUserContact();
   const conversation = await client.conversations.newConversation(
     "0x1852b55b3D59006Db4aAF4f9768b5c38def19156",


### PR DESCRIPTION
All reference Snippets to Client creation now mention `signer` instead of `wallet` 

Eg:

Before:
`const client = await Client.create(wallet,/**/)`

After:
`const client = await Client.create(signer,/**/)`