### PR TITLE
Handle unsupported content types

### DIFF
--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -349,7 +349,7 @@ for await (const page of conversation.messages(limit: 25)) {
 
 As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
 
-Each content type includes a `contentFallback` property. This property provides a string that describes the expected value of the content type. Note that content fallbacks are immutable and are set by default in the protocol. If you are creating custom content types, you have the option to include a custom fallback. For more information on this, please visit the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
+Each content type includes a `contentFallback` property. This property provides a string that describes the expected value of the content type. Note that content fallbacks are immutable and are set by default in network messages. If you are creating custom content types, you have the option to include a custom fallback. For more information on this, please visit the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
@@ -358,8 +358,8 @@ Each content type includes a `contentFallback` property. This property provides 
 const codec = client.codecFor(content.contentType);
 if (!codec) {
   /*Not supported content type*/
-  if (message?.contentFallback !== undefined) {
-    return message?.contentFallback;
+  if (message.contentFallback !== undefined) {
+    return message.contentFallback;
   }
   // Handle other types like ReadReceipts which are not mean to be displayed
 }
@@ -372,8 +372,8 @@ if (!codec) {
 const codec = client.codecFor(content.contentType);
 if (!codec) {
   /*Not supported content type*/
-  if (message?.contentFallback !== undefined) {
-    return message?.contentFallback;
+  if (message.contentFallback !== undefined) {
+    return message.contentFallback;
   }
   // Handle other types like ReadReceipts which are not mean to be displayed
 }
@@ -386,8 +386,8 @@ if (!codec) {
 val codec = client.codecRegistry.find(options?.contentType)
 if (!codec) {
   /*Not supported content type*/
-  if (message?.contentFallback != null) {
-    return message?.contentFallback
+  if (message.contentFallback != null) {
+    return message.contentFallback
   }
   // Handle other types like ReadReceipts which are not meant to be displayed
 }
@@ -398,10 +398,10 @@ if (!codec) {
 
 ```swift
 let codec = client.codecRegistry.find(for: contentType)
-if(!codec){
+if (!codec) {
   /*Not supported content type*/
-  if (message?.contentFallback != null) {
-    return message?.contentFallback
+  if (message.contentFallback != null) {
+    return message.contentFallback
   }
   // Handle other types like ReadReceipts which are not meant to be displayed
 }
@@ -423,7 +423,7 @@ registry.registerCodec(TextCodec());
 // Use the registry to decode the content
 var decoded = await registry.decode(encoded);
 //if the content type doesn't exists. will return `encoded.fallback`
-if(decoded == null){
+if (decoded == null) {
   // Handle other types like ReadReceipts which are not meant to be displayed
 }
 ```

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -358,7 +358,10 @@ Each content type includes a `contentFallback` property. This property provides 
 const codec = client.codecFor(content.contentType);
 if (!codec) {
   /*Not supported content type*/
-  return message?.contentFallback;
+  if (message?.contentFallback !== undefined) {
+    return message?.contentFallback;
+  }
+  // Handle other types like ReadReceipts which are not mean to be displayed
 }
 ```
 
@@ -369,7 +372,10 @@ if (!codec) {
 const codec = client.codecFor(content.contentType);
 if (!codec) {
   /*Not supported content type*/
-  return message?.contentFallback;
+  if (message?.contentFallback !== undefined) {
+    return message?.contentFallback;
+  }
+  // Handle other types like ReadReceipts which are not mean to be displayed
 }
 ```
 
@@ -380,7 +386,10 @@ if (!codec) {
 val codec = client.codecRegistry.find(options?.contentType)
 if (!codec) {
   /*Not supported content type*/
-  return message?.contentFallback
+  if (message?.contentFallback != null) {
+    return message?.contentFallback
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
 }
 ```
 
@@ -391,7 +400,10 @@ if (!codec) {
 let codec = client.codecRegistry.find(for: contentType)
 if(!codec){
   /*Not supported content type*/
-  return message?.contentFallback
+  if (message?.contentFallback != null) {
+    return message?.contentFallback
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
 }
 ```
 
@@ -411,6 +423,9 @@ registry.registerCodec(TextCodec());
 // Use the registry to decode the content
 var decoded = await registry.decode(encoded);
 //if the content type doesn't exists. will return `encoded.fallback`
+if(decoded == null){
+  // Handle other types like ReadReceipts which are not meant to be displayed
+}
 ```
 
 </TabItem>
@@ -420,8 +435,11 @@ var decoded = await registry.decode(encoded);
 const contentTypeID = `${contentType.authorityId}/${contentType.typeId}:${contentType.versionMajor}.${contentType.versionMinor}`;
 const isRegistered = contentTypeID in client.codecRegistry;
 if (!isRegistered) {
-  /*Not supported content type*/
-  return message?.fallback;
+  // Not supported content type
+  if (message?.fallback != null) {
+    return message?.fallback;
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
 }
 ```
 

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -400,6 +400,8 @@ if(!codec){
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
+Dart doesnt have a public method for checking if the content type is registered. Instead the decode function uses this method internally and returns the `encoded.fallback` if exists.
+
 ```jsx
 import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
 import 'package:xmtp/src/content/codec_registry.dart';

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -387,7 +387,7 @@ if (!codec) {
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-```jsx
+```swift
 let codec = client.codecRegistry.find(for: contentType)
 if(!codec){
   /*Not supported content type*/
@@ -400,7 +400,7 @@ if(!codec){
 
 Dart doesnt have a public method for checking if the content type is registered. Instead the decode function uses this method internally and returns the `encoded.fallback` if exists.
 
-```jsx
+```dart
 import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
 import 'package:xmtp/src/content/codec_registry.dart';
 import 'package:xmtp/src/content/text_codec.dart';
@@ -428,4 +428,4 @@ if (!isRegistered) {
 </TabItem>
 </Tabs >
 
-_Note: `Composite` and `ReadReceipts` have an `undefined` fallback, indicating the message is not expected to be displayed._
+_Note: `ReadReceipts` have an `undefined` or `nil` fallback, indicating the message is not expected to be displayed._

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -345,20 +345,22 @@ for await (const page of conversation.messages(limit: 25)) {
 </TabItem>
 </Tabs>
 
-## Handle an unsupported content type error
+## Handle unsupported content types
 
-As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types enter the XMTP ecosystem, your app might receive a content type your app doesn't support. This could crash your app.
+As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
+
+Each content type includes a `contentFallback` property. This property provides a string that describes the expected value of the content type. Note that content fallbacks are immutable and are set by default in the protocol. If you are creating custom content types, you have the option to include a custom fallback. For more information on this, please visit the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
+
+_Note: `Composite` and `ReadReceipts` have an `undefined` `fallback`, indicating the message is not expected to be displayed._
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-To avoid crashing your app, code your app to detect, log, and handle the error. For example:
-
 ```jsx
-const codec = xmtp.codecFor(content.contentType);
+const codec = client.codecFor(content.contentType);
 if (!codec) {
-  const fallback = `missing codec for content type "${content.contentType.toString()}"`;
-  throw new Error(fallback);
+  /*Not supported content type*/
+  return message?.contentFallback;
 }
 ```
 
@@ -366,47 +368,60 @@ if (!codec) {
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
 ```tsx
-// If you wish to display an unsupported content type, there’s a contentFallback
-// property that may include a useful string. However, it is recommended that
-// you manually process unsupported content types.
-import { ContentTypeId } from "@xmtp/xmtp-js";
-import { ContentTypeAttachment } from "@xmtp/content-type-remote-attachment";
-
-const MessageContent = ({ message }) => {
-  if (
-    message.content === undefined &&
-    ContentTypeId.fromString(message.contentType).sameAs(ContentTypeAttachment)
-  ) {
-    return "This message contains an attachment, which is not supported by this client.";
-  }
-};
+const codec = client.codecFor(content.contentType);
+if (!codec) {
+  /*Not supported content type*/
+  return message?.contentFallback;
+}
 ```
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
-Code sample coming soon
+```kotlin
+val codec = client.codecRegistry.find(options?.contentType)
+if (!codec) {
+  /*Not supported content type*/
+  return message?.contentFallback
+}
+```
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
-Code sample coming soon
+```jsx
+let codec = client.codecRegistry.find(for: contentType)
+if(!codec){
+  /*Not supported content type*/
+  return message?.contentFallback
+}
+```
 
 </TabItem>
 <TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
 
-Code sample coming soon
+```jsx
+import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
+import 'package:xmtp/src/content/codec_registry.dart';
+import 'package:xmtp/src/content/text_codec.dart';
+
+// Create a CodecRegistry and register a TextCodec
+var registry = CodecRegistry();
+registry.registerCodec(TextCodec());
+// Use the registry to decode the content
+var decoded = await registry.decode(encoded);
+//if the content type doesn't exists. will return `encoded.fallback`
+```
 
 </TabItem>
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```jsx
-if(/*Not supported content type*/){
-  return message?.fallback ? (
-    message?.fallback
-  ) : (
-    <div style={styles.RenderedMessage}>"Message not supported"</div>
-  );
+const contentTypeID = `${contentType.authorityId}/${contentType.typeId}:${contentType.versionMajor}.${contentType.versionMinor}`;
+const isRegistered = contentTypeID in client.codecRegistry;
+if (!isRegistered) {
+  /*Not supported content type*/
+  return message?.fallback;
 }
 ```
 

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -349,7 +349,7 @@ for await (const page of conversation.messages(limit: 25)) {
 
 As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
 
-Each content type is accompanied by a `contentFallback` property, which offers a descriptive string representing the content type's expected value. It's important to note that content fallbacks are immutable and are predefined in network messages. In instances where `contentFallback` is `undefined`, it indicates that the content, such as read receipts, is not intended to be rendered. If you're venturing into creating custom content types, you're provided with the flexibility to specify a custom fallback. For a deeper dive into this, consider exploring the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
+Each message is accompanied by a `contentFallback` property, which offers a descriptive string representing the content type's expected value. It's important to note that content fallbacks are immutable and are predefined in the content type specification. In instances where `contentFallback` is `undefined`, such as read receipts, it indicates that the content is not intended to be rendered. If you're venturing into creating custom content types, you're provided with the flexibility to specify a custom fallback string. For a deeper dive into this, consider exploring the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -349,7 +349,7 @@ for await (const page of conversation.messages(limit: 25)) {
 
 As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and [standards-track](/docs/concepts/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
 
-Each content type includes a `contentFallback` property. This property provides a string that describes the expected value of the content type. Note that content fallbacks are immutable and are set by default in network messages. If you are creating custom content types, you have the option to include a custom fallback. For more information on this, please visit the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
+Each content type is accompanied by a `contentFallback` property, which offers a descriptive string representing the content type's expected value. It's important to note that content fallbacks are immutable and are predefined in network messages. In instances where `contentFallback` is `undefined`, it indicates that the content, such as read receipts, is not intended to be rendered. If you're venturing into creating custom content types, you're provided with the flexibility to specify a custom fallback. For a deeper dive into this, consider exploring the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -351,8 +351,6 @@ As more [custom](/docs/concepts/content-types#create-a-custom-content-type) and 
 
 Each content type includes a `contentFallback` property. This property provides a string that describes the expected value of the content type. Note that content fallbacks are immutable and are set by default in the protocol. If you are creating custom content types, you have the option to include a custom fallback. For more information on this, please visit the [Custom Content Type Tutorial](/docs/tutorials/custom-ct).
 
-_Note: `Composite` and `ReadReceipts` have an `undefined` `fallback`, indicating the message is not expected to be displayed._
-
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
@@ -429,3 +427,5 @@ if (!isRegistered) {
 
 </TabItem>
 </Tabs >
+
+_Note: `Composite` and `ReadReceipts` have an `undefined` fallback, indicating the message is not expected to be displayed._

--- a/docs/build/messages/reaction.mdx
+++ b/docs/build/messages/reaction.mdx
@@ -313,6 +313,8 @@ if (message.contentTypeId === "xmtp.org/reaction:1.0") {
 </TabItem>
 </Tabs>
 
+_To handle unsupported content types, refer to the [fallback](/docs/build/messages/#handle-an-unsupported-content-type-error) section._
+
 ## Display the reaction
 
 Generally, reactions should be interpreted as emoji. So, "smile" would translate to 😄 in UI clients. That being said, how you ultimately choose to render a reaction in your app is up to you.

--- a/docs/build/messages/read-receipt.mdx
+++ b/docs/build/messages/read-receipt.mdx
@@ -259,6 +259,8 @@ if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
 </TabItem>
 </Tabs>
 
+_To handle unsupported content types, refer to the [fallback](/docs/build/messages/#handle-an-unsupported-content-type-error) section._
+
 ## Use a read receipt
 
 Generally, a read receipt indicator should be displayed under the message it's associated with. The indicator can include a timestamp. Ultimately, how you choose to display a read receipt indicator is completely up to you.

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -634,6 +634,8 @@ if (message.contentTypeId === "xmtp.org/remoteStaticAttachment:1.0") {
 }
 ```
 
+_To handle unsupported content types, refer to the [fallback](/docs/build/messages/#handle-an-unsupported-content-type-error) section._
+
 Display the attachment:
 
 ```jsx

--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -634,8 +634,6 @@ if (message.contentTypeId === "xmtp.org/remoteStaticAttachment:1.0") {
 }
 ```
 
-_To handle unsupported content types, refer to the [fallback](/docs/build/messages/#handle-an-unsupported-content-type-error) section._
-
 Display the attachment:
 
 ```jsx
@@ -644,3 +642,5 @@ Display the attachment:
 
 </TabItem>
 </Tabs>
+
+_To handle unsupported content types, refer to the [fallback](/docs/build/messages/#handle-an-unsupported-content-type-error) section._

--- a/docs/build/messages/reply.mdx
+++ b/docs/build/messages/reply.mdx
@@ -317,6 +317,8 @@ if (message.contentTypeId === "xmtp.org/reply:1.0") {
 </TabItem>
 </Tabs>
 
+_To handle unsupported content types, refer to the [fallback](/docs/build/messages/#handle-an-unsupported-content-type-error) section._
+
 ## Display the reply
 
 How you choose to display replies in your app is up to you. It might be useful to look at the user experience for replies in popular apps such as Telegram and Discord.


### PR DESCRIPTION
This PR explains how to recognize un supported content types and display a fallback instead.

- [Preview](https://junk-range-possible-git-fallbackv1-xmtp-labs.vercel.app/docs/build/messages/#handle-unsupported-content-types)