### PR TITLE
URL IOS Docs update

### DIFF
--- a/docs/build/get-started/references.md
+++ b/docs/build/get-started/references.md
@@ -14,7 +14,7 @@ Use these reference docs as comprehensive guides to integrating the capabilities
 
 - [Kotlin SDK reference docs](https://xmtp.github.io/xmtp-android/) - `xmtp-android`
 
-- [Swift SDK reference docs](https://xmtp.github.io/xmtp-ios/documentation/xmtp) - `xmtp-ios`
+- [Swift SDK reference docs](https://xmtp.github.io/xmtp-ios/) - `xmtp-ios`
 
 - [Dart SDK reference docs](https://pub.dev/documentation/xmtp/latest/xmtp/Client-class.html) - `xmtp-flutter`
 


### PR DESCRIPTION
Update `https://xmtp.github.io/xmtp-ios/documentation/xmtp` with new one `https://xmtp.github.io/xmtp-ios/` based on the [PR](https://github.com/xmtp/xmtp-ios/pull/207) fixing the generated docs.

- [Preview Docs](https://xmtp.github.io/xmtp-ios/)