### PR TITLE
Portable Consent Update

### DIFF
--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -164,8 +164,8 @@ The user consent feature for Dart hasn't been implemented yet
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx
-client.contacts.allow([wantedConvo.peerAddress, wantedConvo.peerAddress]);
-client.contacts.deny([spamConvo.peerAddress, unwantedConvo.peerAddress]);
+await client.contacts.allow([wantedConvo.peerAddress, wantedConvo.peerAddress]);
+await client.contacts.deny([spamConvo.peerAddress, unwantedConvo.peerAddress]);
 ```
 
 </TabItem>
@@ -225,7 +225,7 @@ The user consent feature for Dart hasn't been implemented yet
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx
-client.contacts.refreshConsentList();
+await client.contacts.refreshConsentList();
 ```
 
 </TabItem>
@@ -283,7 +283,7 @@ The user consent feature for Dart hasn't been implemented yet
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx
-client.contacts.consentList();
+await client.contacts.consentList();
 ```
 
 </TabItem>
@@ -354,8 +354,8 @@ The user consent feature for Dart hasn't been implemented yet
 <TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
 
 ```tsx
-client.contacts.isAllowed(wantedConvo.peerAddress);
-client.contacts.isDenied(spamConvo.peerAddress);
+await client.contacts.isAllowed(wantedConvo.peerAddress);
+await client.contacts.isDenied(spamConvo.peerAddress);
 ```
 
 </TabItem>
@@ -480,7 +480,26 @@ export default ConsentListStreamer;
 ```
 
 </TabItem>
+<TabItem value="kotlin" label="Kotlin" attributes={{className: "kotlin_tab"}}>
 
+Code sample coming soon
+
+</TabItem>
+<TabItem value="swift" label="Swift" attributes={{className: "swift_tab"}}>
+
+Code sample coming soon
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+Code sample coming soon
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+Code sample coming soon
+
+</TabItem>
 </Tabs>
 
 ## Synchronize user consent preferences

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -116,8 +116,6 @@ await conversation.deny();
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-In the React SDK, we provide a convenient hook `useConsent` for managing consent.
-
 ```jsx
 import { useConsent } from "@xmtp/react-sdk";
 

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -116,7 +116,30 @@ await conversation.deny();
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-The user consent feature for React hasn't been implemented yet
+In the React SDK, we provide a convenient hook `useConsent` for managing consent.
+
+```jsx
+import { useConsent } from "@xmtp/react-sdk";
+
+function ConsentControl({ conversation }) {
+  const { allow, deny } = useConsent();
+
+  const handleAllow = async () => {
+    await allow([conversation.peerAddress]);
+    // Additional UI logic or state updates after allowing
+  };
+
+  const handleDeny = async () => {
+    await deny([conversation.peerAddress]);
+    // Additional UI logic or state updates after denying
+  };
+
+  return (
+    // ... UI elements that call handleAllow and handleDeny
+  );
+}
+
+```
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -166,7 +189,20 @@ await client.contacts.refreshConsentList();
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-The user consent feature for React hasn't been implemented yet
+```jsx
+import { useEffect } from "react";
+import { useConsent } from "@xmtp/react-sdk";
+
+function ConsentList() {
+  const { refreshConsentList } = useConsent();
+
+  useEffect(() => {
+    void refreshConsentList();
+  }, []);
+
+  // ... UI rendering
+}
+```
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -213,7 +249,20 @@ await client.contacts.loadConsentList(lastSyncedDate);
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-The user consent feature for React hasn't been implemented yet
+```jsx
+import { useEffect } from "react";
+import { useConsent } from "@xmtp/react-sdk";
+
+function LoadConsentList() {
+  const { loadConsentList } = useConsent();
+
+  useEffect(() => {
+    void (loadConsentList(/* Optional: startTime */));
+  }, []);
+
+  // ... UI rendering
+}
+```
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -251,7 +300,7 @@ Call the following methods to check if a contact is denied or allowed.
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
-```js
+```jsx
 // from the client
 const isAllowed = client.contacts.isAllowed(address);
 const isDenied = client.contacts.isDenied(address);
@@ -264,7 +313,25 @@ const isDenied = conversation.isDenied;
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-The user consent feature for React hasn't been implemented yet
+```jsx
+import { useConsent } from "@xmtp/react-sdk";
+
+function CheckConsent({ conversation }) {
+  const { isAllowed, isBlocked } = useConsent();
+
+  useEffect(() => {
+    const checkConsent = async () => {
+      const allowed = await isAllowed(conversation.peerAddress);
+      const blocked = await isBlocked(conversation.peerAddress);
+      // Use `allowed` and `blocked` for UI updates or logic
+    };
+
+    checkConsent();
+  }, [conversation.peerAddress]);
+
+  // ... UI rendering based on consent status
+}
+```
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -311,12 +378,25 @@ const consentState = client.contacts.consentState(peerAddress);
 
 // from a conversation
 const consentState = conversation.consentState;
+
+// consentState can be 'allowed', 'denied', or 'unknown'
 ```
 
 </TabItem>
 <TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
 
-The user consent feature for React hasn't been implemented yet
+```jsx
+import { useConsent } from "@xmtp/react-sdk";
+
+function ConversationConsent({ conversation }) {
+  const { consentState } = useConsent();
+
+  const state = consentState(conversation.peerAddress);
+  // state can be 'allowed', 'denied', or 'unknown'
+
+  // ... UI rendering based on the state
+}
+```
 
 </TabItem>
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
@@ -356,7 +436,7 @@ if (state === "denied") {
 </TabItem>
 </Tabs>
 
-## Streaming the Consent List
+## Streaming the consent list
 
 This section provides an example of how to stream the consent list. The code snippet below demonstrates how to create a new conversation and then stream the consent list, logging each action to the console.
 
@@ -372,6 +452,39 @@ await aliceStream.return();
 ```
 
 </TabItem>
+
+<TabItem value="react" label="React" attributes={{className: "react_tab"}}>
+
+```jsx
+import { useStreamConsentList } from "@xmtp/react-sdk";
+
+function ConsentListStreamer() {
+  const handleAction = (action) => {
+    console.log("New action received:", action);
+    // You can update your UI or state based on the action here
+  };
+
+  const handleError = (error) => {
+    console.error("Error in streaming consent list:", error);
+    // Handle error state in UI
+  };
+
+  const { error } = useStreamConsentList(handleAction, handleError);
+
+  return (
+    <div>
+      <h3>Consent List Stream</h3>
+      {error && <p>Error: {error.message}</p>}
+      {/* Additional UI for showing streaming status or actions */}
+    </div>
+  );
+}
+
+export default ConsentListStreamer;
+```
+
+</TabItem>
+
 </Tabs>
 
 ## Synchronize user consent preferences

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -356,6 +356,24 @@ if (state === "denied") {
 </TabItem>
 </Tabs>
 
+## Streaming the Consent List
+
+This section provides an example of how to stream the consent list. The code snippet below demonstrates how to create a new conversation and then stream the consent list, logging each action to the console.
+
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript" attributes={{className: "js_tab"}}>
+
+```js
+const aliceStream = await aliceClient.contacts.streamConsentList();
+for await (const action of aliceStream) {
+  // Each action indicates the address and if it's allowed or denied
+}
+await aliceStream.return();
+```
+
+</TabItem>
+</Tabs>
+
 ## Synchronize user consent preferences
 
 All apps that use the user consent feature must adhere to the logic described in this section to keep the consent list on the network synchronized with local app user consent preferences, and vice versa.

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -240,10 +240,8 @@ Load the consent list from a specific time. If no time is specified, it loads th
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript" attributes={{className: "js_tab"}}>
 
-The `lastSyncedDate` parameter is optional.
-
 ```js
-await client.contacts.loadConsentList(lastSyncedDate);
+await client.contacts.loadConsentList(/* Optional: lastSyncedDate */);
 ```
 
 </TabItem>
@@ -257,7 +255,7 @@ function LoadConsentList() {
   const { loadConsentList } = useConsent();
 
   useEffect(() => {
-    void (loadConsentList(/* Optional: startTime */));
+    void (loadConsentList(/* Optional: lastSyncedDate */));
   }, []);
 
   // ... UI rendering

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -317,12 +317,12 @@ const isDenied = conversation.isDenied;
 import { useConsent } from "@xmtp/react-sdk";
 
 function CheckConsent({ conversation }) {
-  const { isAllowed, isBlocked } = useConsent();
+  const { isAllowed, isDenied } = useConsent();
 
   useEffect(() => {
     const checkConsent = async () => {
       const allowed = await isAllowed(conversation.peerAddress);
-      const blocked = await isBlocked(conversation.peerAddress);
+      const blocked = await isDenied(conversation.peerAddress);
       // Use `allowed` and `blocked` for UI updates or logic
     };
 

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -14,12 +14,6 @@ import consentlogic from '/docs/build/img/consent-state-logic.png';
 
 ![Feature status](https://img.shields.io/badge/Feature_status-Alpha-orange)
 
-:::caution This feature is in **alpha** status
-
-This feature is in **alpha** status and ready for you to start experimenting with. However, we do not recommend using alpha features in production apps. Expect frequent changes as we iterate based on feedback. Want to provide feedback? Comment on [Proposal: Portable consent state for v2 SDKs](https://github.com/orgs/xmtp/discussions/49). 
-
-:::
-
 The user consent feature enables your app to request and respect user consent preferences. With this feature, another blockchain account address registered on the XMTP network can have one of three consent preference values:
 
 - Unknown
@@ -46,11 +40,11 @@ Conversation created in an app on an SDK version **without** user consent suppor
 
 Conversation created in an app on an SDK version **with** user consent support:
 
-- For a new conversation that a user created with a peer contact, the SDK sets the consent preference to `allowed`.  
+- For a new conversation that a user created with a peer contact, the SDK sets the consent preference to `allowed`.
 
   The user’s creation of the conversation with the contact is considered consent.
 
-- For an existing conversation created by a peer contact that hasn’t had its consent preference updated on the network (`unknown`) and that the user responds to, the SDK will update the consent preference to `allowed`.  
+- For an existing conversation created by a peer contact that hasn’t had its consent preference updated on the network (`unknown`) and that the user responds to, the SDK will update the consent preference to `allowed`.
 
   The user's response to the conversation is considered consent.
 
@@ -82,16 +76,18 @@ Here are some suggestions for how your app might provide user experiences that r
 
 **Unknown**
 
-Consider displaying a conversation with an `unknown` contact on a **Requests** tab and give the user the option to block or allow the contact.  
+Consider displaying a conversation with an `unknown` contact on a **Requests** tab and give the user the option to block or allow the contact.
 
 <img src={requeststab} style={{width:"375px"}}/>
+
 <p/>
 
 **Allowed**
 
-Consider displaying a conversation with an `allowed` contact on a **Messages** tab and give the user the option to block the contact.  
+Consider displaying a conversation with an `allowed` contact on a **Messages** tab and give the user the option to block the contact.
 
 <img src={messagestab} style={{width:"375px"}}/>
+
 <p/>
 
 **Denied**
@@ -167,7 +163,8 @@ To ensure that you’re using the latest consent preferences, make sure to refre
 // load the entire consent list
 await client.contacts.refreshConsentList();
 
-// load the consent list from a specific time
+// Load the consent list from a specific time. If no time is specified, it loads the consent list from the last time the refresh was made.
+// The 'lastSyncedDate' parameter is optional.
 await client.contacts.loadConsentList(lastSyncedDate);
 ```
 
@@ -310,7 +307,7 @@ The user consent feature for Dart hasn't been implemented yet
 ```tsx
 const state = await conversation.consentState();
 if (state === "denied") {
-	// hide the conversation
+  // hide the conversation
 }
 ```
 
@@ -337,6 +334,6 @@ Update a consent preference in the consent list on the network in the following 
 
 - An existing conversation has an `unknown` consent preference, but has an existing response from the user. The app should update the consent preference in the consent list to `allowed`.
 
-The following diagram illustrates the detailed logic for how user consent preferences are set in an app and in the consent list on the XMTP network. 
+The following diagram illustrates the detailed logic for how user consent preferences are set in an app and in the consent list on the XMTP network.
 
 <img src={consentlogic} style={{width:"90%"}}/>

--- a/docs/build/user-consent.md
+++ b/docs/build/user-consent.md
@@ -12,8 +12,6 @@ import consentlogic from '/docs/build/img/consent-state-logic.png';
 
 # Request and respect user consent
 
-![Feature status](https://img.shields.io/badge/Feature_status-Alpha-orange)
-
 The user consent feature enables your app to request and respect user consent preferences. With this feature, another blockchain account address registered on the XMTP network can have one of three consent preference values:
 
 - Unknown
@@ -124,16 +122,16 @@ The user consent feature for React hasn't been implemented yet
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
-client.contacts.isAllowed(wantedConvo.peerAddress)
-client.contacts.isDenied(spamConvo.peerAddress)
+client.contacts.allow([wantedConvo.peerAddress, wantedConvo.peerAddress])
+client.contacts.deny([spamConvo.peerAddress, unwantedConvo.peerAddress])
 ```
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
-await client.contacts.isAllowed(wantedConvo.peerAddress)
-await client.contacts.isDenied(spamConvo.peerAddress)
+try await client.contacts.allow(addresses: [wantedConvo.peerAddress, wantedConvo.peerAddress])
+try await client.contacts.deny(addresses: [spamConvo.peerAddress, unwantedConvo.peerAddress])
 ```
 
 </TabItem>
@@ -156,16 +154,13 @@ client.contacts.deny([spamConvo.peerAddress, unwantedConvo.peerAddress]);
 
 To ensure that you’re using the latest consent preferences, make sure to refresh the consent list from the network. Perform the refresh just in case the consent preference has changed on a different device, for example.
 
+- `refreshConsentList()` returns the history of all consent entries.
+
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>
 
 ```js
-// load the entire consent list
 await client.contacts.refreshConsentList();
-
-// Load the consent list from a specific time. If no time is specified, it loads the consent list from the last time the refresh was made.
-// The 'lastSyncedDate' parameter is optional.
-await client.contacts.loadConsentList(lastSyncedDate);
 ```
 
 </TabItem>
@@ -177,16 +172,14 @@ The user consent feature for React hasn't been implemented yet
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
-client.contacts.allow([wantedConvo.peerAddress, wantedConvo.peerAddress])
-client.contacts.deny([spamConvo.peerAddress, unwantedConvo.peerAddress])
+client.contacts.refreshConsentList()
 ```
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
-try await client.contacts.allow(addresses: [wantedConvo.peerAddress, wantedConvo.peerAddress])
-try await client.contacts.deny(addresses: [spamConvo.peerAddress, unwantedConvo.peerAddress])
+try await client.contacts.refreshConsentList()
 ```
 
 </TabItem>
@@ -199,6 +192,53 @@ The user consent feature for Dart hasn't been implemented yet
 
 ```tsx
 client.contacts.refreshConsentList();
+```
+
+</TabItem>
+</Tabs>
+
+### Get the consent list
+
+Load the consent list from a specific time. If no time is specified, it loads the consent list from the last time the refresh was made.
+
+<Tabs groupId="sdk-langs">
+<TabItem value="js" label="JavaScript" attributes={{className: "js_tab"}}>
+
+The `lastSyncedDate` parameter is optional.
+
+```js
+await client.contacts.loadConsentList(lastSyncedDate);
+```
+
+</TabItem>
+<TabItem value="react" label="React"  attributes={{className: "react_tab"}}>
+
+The user consent feature for React hasn't been implemented yet
+
+</TabItem>
+<TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
+
+```kotlin
+client.contacts.consentList
+```
+
+</TabItem>
+<TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
+
+```swift
+try await client.contacts.consentList
+```
+
+</TabItem>
+<TabItem value="dart" label="Dart"  attributes={{className: "dart_tab"}}>
+
+The user consent feature for Dart hasn't been implemented yet
+
+</TabItem>
+<TabItem value="rn" label="React Native"  attributes={{className: "rn_tab"}}>
+
+```tsx
+client.contacts.consentList();
 ```
 
 </TabItem>
@@ -230,14 +270,16 @@ The user consent feature for React hasn't been implemented yet
 <TabItem value="kotlin" label="Kotlin"  attributes={{className: "kotlin_tab"}}>
 
 ```kotlin
-client.contacts.refreshConsentList()
+client.contacts.isAllowed(wantedConvo.peerAddress)
+client.contacts.isDenied(spamConvo.peerAddress)
 ```
 
 </TabItem>
 <TabItem value="swift" label="Swift"  attributes={{className: "swift_tab"}}>
 
 ```swift
-try await client.contacts.refreshConsentList()
+await client.contacts.isAllowed(wantedConvo.peerAddress)
+await client.contacts.isDenied(spamConvo.peerAddress)
 ```
 
 </TabItem>

--- a/docs/concepts/architectural-overview.md
+++ b/docs/concepts/architectural-overview.md
@@ -23,7 +23,7 @@ At the most basic level, the architecture of XMTP includes three layers:
 
 The network layer provides the XMTP network, which is composed of **nodes** (computers) running XMTP node software.
 
-The XMTP network enables any computer running XMTP node software to participate in the network. Currently, the node software is closed source and all nodes in the XMTP network are operated by XMTP Labs. XMTP Labs is working toward a phased decentralization of the network. To learn more, see [XMTP: The journey to decentralization](/blog/journey-to-decentralization).
+The XMTP network enables any computer running XMTP node software to participate in the network. Currently, the node software is closed source and all nodes in the XMTP network are operated by XMTP Labs. XMTP Labs is working toward a phased decentralization of the network. To learn more, see [Decentralizing XMTP, a minimum viable proposal ](https://community.xmtp.org/t/decentralizing-xmtp-a-minimum-viable-proposal/510).
 
 This diagram shows the key components of an XMTP node. The nodes provide a **message API** that enables client apps built with the XMTP client SDK to communicate with the nodes in the XMTP network. The nodes use Waku node software to connect to other nodes and form a peer-to-peer network to relay and store envelopes submitted and requested by client apps.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -198,7 +198,7 @@ These network nodes operate in US jurisdiction in compliance with Office of Fore
 
 To explore the software for the nodes that currently form the XMTP network, see the [xmtp-node-go repo](https://github.com/xmtp/xmtp-node-go).
 
-XMTP Labs is working toward a phased decentralization of the network. To learn more, see [XMTP: The journey to decentralization](/blog/journey-to-decentralization).
+XMTP Labs is working toward a phased decentralization of the network. To learn more, see [Decentralizing XMTP, a minimum viable proposal ](https://community.xmtp.org/t/decentralizing-xmtp-a-minimum-viable-proposal/510).
 
 Decentralization of the XMTP network will be achieved by a diverse set of independent third parties operating nodes all over the world. Decentralization is a top priority and is required to ensure that XMTP is able to serve everyone on the planet.
 
@@ -212,7 +212,7 @@ XMTP Labs is researching various consensus protocols that would allow the networ
 
 Yes, you will be able to run a node.
 
-XMTP Labs is working toward a phased decentralization of the network. To learn more, see [XMTP: The journey to decentralization](/blog/journey-to-decentralization).
+XMTP Labs is working toward a phased decentralization of the network. To learn more, see [Decentralizing XMTP, a minimum viable proposal ](https://community.xmtp.org/t/decentralizing-xmtp-a-minimum-viable-proposal/510).
 
 ### What is the relationship between Waku and XMTP?
 
@@ -236,7 +236,7 @@ We don't provide a direct method to fetch all XMTP-enabled wallet addresses in b
 
 ### Does XMTP support group chat?
 
-Not yet. Despite efforts to build group chat with XMTP v2 (the current protocol version), protocol limitations prevented group chat from meeting XMTP's robust security standards. Efforts have shifted to updating the protocol to support secure group chat. More details to come. 
+Not yet. Despite efforts to build group chat with XMTP v2 (the current protocol version), protocol limitations prevented group chat from meeting XMTP's robust security standards. Efforts have shifted to updating the protocol to support secure group chat. More details to come.
 
 Have other questions or feedback about group chat? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 


### PR DESCRIPTION
Updated some snippets and features based on the latest of [JS](https://github.com/xmtp/xmtp-js/releases/tag/v11.3.0) and [React](https://github.com/xmtp/xmtp-web/releases/tag/%40xmtp%2Freact-sdk%403.1.0) 

- [Preview](https://junk-range-possible-git-consentrelease-xmtp-labs.vercel.app/docs/build/user-consent)