### PR TITLE
Add rate limit increase form link

### DIFF
--- a/docs/concepts/architectural-overview.md
+++ b/docs/concepts/architectural-overview.md
@@ -31,7 +31,7 @@ This diagram shows the key components of an XMTP node. The nodes provide a **mes
 
 ![Diagram showing three nodes connected in a peer-to-peer fashion to form the XMTP network. The diagram shows the key components of a node, including a message API and Waku node. The diagram also shows a client app connecting a message API client to the message API in a node.](img/xmtp-nodes.png)<!--Source file: [https://www.figma.com/file/77ToMB4T16NiLwJjIp7dU1/diagrams?type=design&node-id=16-502&mode=design)-->
 
-Currently, nodes are configured to rate limit high-volume publishing from message API clients. A rate-limited message API client can expect to receive a 429 status code response from a node. Rate limits can change at any time in the interest of maintaining network health.
+Currently, nodes are configured to rate limit high-volume publishing from message API clients. A rate-limited message API client can expect to receive a 429 status code response from a node. Rate limits can change at any time in the interest of maintaining network health. To learn more, see [Rate limiting](/docs/faq#rate-limiting).
 
 Every **envelope** contains a payload, often encrypted, that is not observable by nodes. The payload could be a public key bundle, private key bundle, or a message created by a client app, but this information is opaque to nodes. Meaning is assigned to these envelopes in the [Client layer](#client-layer).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -240,33 +240,35 @@ Not yet. Despite efforts to build group chat with XMTP v2 (the current protocol 
 
 Have other questions or feedback about group chat? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
-## Rate Limiting
+## Rate-limiting
 
 ---
 
-### How does network rate limiting work?
+### How does network rate-limiting work?
 
-Currently, XMTP network nodes are configured to rate limit high-volume publishing from clients. A rate-limited client can expect to receive a 429 status code response from a node.
+Currently, XMTP network nodes are configured to rate-limit high-volume publishing from clients. A rate-limited client can expect to receive a 429 status code response from a node.
 
-XMTP Labs is capable of rate limiting the network while we are the only node operators. Rate limiting is a consideration in our research into economic spam controls. Ultimately, rate limiting decisions will be made based on maintaining network quality and reducing the potential for malicious attacks by senders and nodes.
+XMTP Labs is capable of rate-limiting the network while we are the only node operators. Rate-limiting is a consideration in our research into economic spam controls. Ultimately, rate-limiting decisions will be made based on maintaining network quality and reducing the potential for malicious attacks by senders and nodes.
 
-### What are the API rate limits?
+### What are the API rate-limits?
 
 - 1,000 publish requests per 5 minutes.
 - 10,000 general requests per 5 minutes.
 - Nodes allow 40,000 reads per 5 minutes.
 
+If your requirements exceed these limits, [submit this form](https://docs.google.com/forms/d/e/1FAIpQLSftr558wsYD2X_0c1Jsz6rTxua1f1DDJidAn7iphJVc48l7Fw/viewform) to share more details with the XMTP Labs team.
+
 ### What happens if I exceed the limits?
 
 You'll get an HTTP 429 error and must wait for the next 5-minute window.
 
-Tips for Staying Within Limits
+Tips for staying within limits:
 
-- Spread out your requests over 5 minutes.
+- Spread your requests over 5 minutes.
 - Use smaller batches for large queries.
 - Introduce a brief delay between calls.
 - Use multiple IPs to make requests.
-- Bulk canMessage makes api calls in 50 address batches
+- Bulk `canMessage` makes API calls in 50-address batches.
 
 By being aware of these limits and planning accordingly, you can avoid rate-limiting issues.
 

--- a/docs/tutorials/debug-and-test.md
+++ b/docs/tutorials/debug-and-test.md
@@ -84,7 +84,7 @@ $ npm start intros list
 $ ...
 ```
 
-Populating test wallets might cause you to exceed the XMTP network rate limit. If this happens, wait 5 minutes and try again.
+Populating test wallets might cause you to exceed the XMTP network rate limit. If this happens, wait 5 minutes and try again. To learn more, see [Rate limiting](/docs/faq#rate-limiting).
 
 ## Test your app
 


### PR DESCRIPTION
Added a link to the Request Rate Limit Increase form to the Rate-limiting FAQ section.

[Preview here](https://junk-range-possible-git-rate-limit-details-xmtp-labs.vercel.app/docs/faq#what-are-the-api-rate-limits)