### PR TITLE
Add max message size to docs

### DIFF
--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -13,7 +13,9 @@ The message payload can be a plain string, but you can configure custom content 
 
 ## Send messages
 
-To send a message, the recipient must have already started their client at least once and consequently advertised their key bundle on the network.
+To send a message, the recipient must have already started their client at least once and consequently advertised their key bundle on the network. 
+
+Messages can be up to 1MB only. Use [remote attachments](/docs/build/messages/remote-attachment) to support larger messages.
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>

--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -15,7 +15,7 @@ The message payload can be a plain string, but you can configure custom content 
 
 To send a message, the recipient must have already started their client at least once and consequently advertised their key bundle on the network. 
 
-Messages can be up to 1MB only. Use [remote attachments](/docs/build/messages/remote-attachment) to support larger messages.
+Messages are limited to just short of 1MB (1048214 bytes) . Use [remote attachments](/docs/build/messages/remote-attachment) to support larger messages.
 
 <Tabs groupId="sdk-langs">
 <TabItem value="js" label="JavaScript"  attributes={{className: "js_tab"}}>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -370,7 +370,7 @@ Have other questions or ideas about message formats and metadata? Post to the [X
 
 ### Does XMTP have a maximum message size?
 
-Yes. Messages sent on the XMTP network can be up to 1MB only.
+Yes. Messages sent on the XMTP network are limited to just short of 1MB (1048214 bytes).
 
 For this reason, XMTP supports [message attachments](#does-xmtp-support-message-attachments).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -368,6 +368,12 @@ To learn more about the XMTP improvement proposals governance process, see [What
 
 Have other questions or ideas about message formats and metadata? Post to the [XMTP Community Forums](https://community.xmtp.org/).
 
+### Does XMTP have a maximum message size?
+
+Yes. Messages sent on the XMTP network can be up to 1MB only.
+
+For this reason, XMTP supports [message attachments](#does-xmtp-support-message-attachments).
+
 ### Does XMTP support message attachments?
 
 Yes, via two XMTP improvement proposals that are currently in review status:
@@ -375,11 +381,7 @@ Yes, via two XMTP improvement proposals that are currently in review status:
 - [XIP-15](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-15-attachment-content-type.md): Attachment content type
 - [XIP-17](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-17-remote-attachment-content-type-proposal.md): Remote attachment content type
 
-To learn more about how to implement message attachments in your app, see:
-
-- For apps using the JavaScript client SDK (`xmtp-js`), see [Remote attachment content type](/docs/build/messages/remote-attachment).
-
-- For apps using the Swift client SDK (`xmtp-ios`), see [Send a remote attachment](https://github.com/xmtp/xmtp-ios#send-a-remote-attachment).
+To learn how to implement message attachments in your app, see [Remote attachment content type](/docs/build/messages/remote-attachment).
 
 ### Does XMTP support deleting and editing messages?
 


### PR DESCRIPTION
Per feedback, let's add maximum message size info to the docs. Max message size is 1MB.

- [FAQ preview link ](https://junk-range-possible-git-message-size-xmtp-labs.vercel.app/docs/faq#does-xmtp-have-a-maximum-message-size)
- [Send messages preview link](https://junk-range-possible-git-message-size-xmtp-labs.vercel.app/docs/build/messages/#send-messages)