### PR TITLE
Correct codec registration doc

### DIFF
--- a/docs/build/messages/remote-attachment.mdx
+++ b/docs/build/messages/remote-attachment.mdx
@@ -42,9 +42,10 @@ import {
   ContentTypeRemoteAttachment,
 } from "@xmtp/content-type-remote-attachment";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new AttachmentCodec());
-xmtp.registerCodec(new RemoteAttachmentCodec());
+const xmtp = await Client.create(signer, { 
+    env: "dev",
+    codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()]
+});
 ```
 
 </TabItem>


### PR DESCRIPTION
It appears that the means to register codecs has changed since the original doc was written - when I was following this and tried using the `registerCodec` function, the runtime failed and complained about that not being an actual function.

I believe this is how to properly provision the codecs (or, at least, I've gotten it near-enough running by provisioning the codecs this way running locally on my own machine).