### PR TITLE
Fixing a broken H2

### DIFF
--- a/docs/build/messages/messages.md
+++ b/docs/build/messages/messages.md
@@ -345,12 +345,14 @@ for await (const page of conversation.messages(limit: 25)) {
 
 </TabItem>
 </Tabs>
- 
-## Note on Group Chats
+
+:::infoNote on Group Chats
 
 The methods for sending and listing messages, as well as handling unsupported content types, are applicable to both one-on-one and group conversations within XMTP. This means you can use the same approach to manage messages in group chats as you would in individual conversations.
 
 For additional information on group chat-specific features, such as managing group members or listening for new messages in a group chat, please see the [Group Chat](/docs/build/group-chat) documentation.
+
+:::
 
 ## Handle unsupported content types
 

--- a/docs/v3/_category_.json
+++ b/docs/v3/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "V3 Alpha",
+  "label": "Group Chat Alpha",
   "position": 45,
   "collapsible": true,
   "collapsed": false

--- a/docs/v3/_category_.json
+++ b/docs/v3/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Group Chat Alpha",
+  "label": "V3 Alpha",
   "position": 45,
   "collapsible": true,
   "collapsed": false


### PR DESCRIPTION
I noticed when reading this page the H2 was broken.  Removing a space fixed the header, but I thought since it was titled as a "Note" the thing to do would be to make it a Note.  I chose Info just because I like the contrast of the blue instead of the white.

If the note is too much we can fix the topic by just fixing the space preventing the H2 from rendering.