### PR TITLE
Fix: typos and update links in contribute.md and index.js

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -33,7 +33,7 @@ Keep up with the latest news and insights from XMTP.
 
 ## Open source projects
 
-XMTP welcomes contributions to any of the public repos in the [XMTP](https://github.com/xmtp) and [Ephemera](https://github.com/xmtp-labs) GitHub orgs.
+XMTP welcomes contributions to any of the public repos in the [XMTP](https://github.com/xmtp) and [Ephemera](https://github.com/ephemeraHQ) GitHub orgs.
 
 ### 🐞 Bugs
 
@@ -47,7 +47,7 @@ Request features by creating an issue in the [related XMTP GitHub repo](https://
 
 We encourage pull requests (PRs) from the community, but we suggest that you start with a feature request or a post to the [XMTP Community Forums](https://community.xmtp.org/) just to do a temperature check. For example, if the PR involves a major change to the XMTP protocol, it must be fleshed out as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) before work begins.
 
-If your PR to a repo in the [XMTP](https://github.com/xmtp) or [Ephemera](https://github.com/xmtp-labs) GitHub org is meerged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
+If your PR to a repo in the [XMTP](https://github.com/xmtp) or [Ephemera](https://github.com/ephemeraHQ) GitHub org is meerged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
 
 ## XMTP Improvement Proposals
 

--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -47,7 +47,7 @@ Request features by creating an issue in the [related XMTP GitHub repo](https://
 
 We encourage pull requests (PRs) from the community, but we suggest that you start with a feature request or a post to the [XMTP Community Forums](https://community.xmtp.org/) just to do a temperature check. For example, if the PR involves a major change to the XMTP protocol, it must be fleshed out as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) before work begins.
 
-If your PR to a repo in the [XMTP](https://github.com/xmtp) or [Ephemera](https://github.com/ephemeraHQ) GitHub org is meerged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
+If your PR to a repo in the [XMTP](https://github.com/xmtp) or [Ephemera](https://github.com/ephemeraHQ) GitHub org is merged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
 
 ## XMTP Improvement Proposals
 

--- a/src/components/HeaderBox/index.js
+++ b/src/components/HeaderBox/index.js
@@ -8,7 +8,7 @@ export const HeaderBox = ({ title, subtitle, url, styles, icon }) => {
         className={`${styles.headerBox} xl:min-h-[300px] rounded-lg border border-solid border-black dark:border-neutral-700 relative group px-6 pb-6 pt-6 md:pt-6 lg:px-8 lg:pt-8 lg:pb-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500 transition-all hover:shadow-lg`}
       >
         <div>
-          <h4 className="inline-flex text-lg font-semibold text-red-500 md:text-x">
+          <h4 className="inline-flex text-lg font-semibold text-red-500 md:text-xl">
             {title}
           </h4>
         </div>


### PR DESCRIPTION
This PR addresses a few small but important changes:  
1. **`contribute.md`:**  
   - Updated broken links:  
     - Changed the `Ephemera` link from `https://github.com/xmtp-labs` to `https://github.com/ephemeraHQ`.  
   - Fixed a typo: `meerged` → `merged`.  

2. **`index.js`:**  
   - Corrected a minor formatting issue: updated `md:text-x` to `md:text-xl` for better readability.