### PR TITLE
Fix incorrect Ephemera links

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -33,7 +33,7 @@ Keep up with the latest news and insights from XMTP.
 
 ## Open source projects
 
-XMTP welcomes contributions to any of the public repos in the [XMTP](https://github.com/xmtp) and [Ephemera](https://github.com/xmtp-labs) GitHub orgs.
+XMTP welcomes contributions to any of the public repos in the [XMTP](https://github.com/xmtp) and [Ephemera](https://github.com/ephemeraHQ) GitHub orgs.
 
 ### 🐞 Bugs
 
@@ -47,7 +47,7 @@ Request features by creating an issue in the [related XMTP GitHub repo](https://
 
 We encourage pull requests (PRs) from the community, but we suggest that you start with a feature request or a post to the [XMTP Community Forums](https://community.xmtp.org/) just to do a temperature check. For example, if the PR involves a major change to the XMTP protocol, it must be fleshed out as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md) before work begins.
 
-If your PR to a repo in the [XMTP](https://github.com/xmtp) or [Ephemera](https://github.com/xmtp-labs) GitHub org is meerged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
+If your PR to a repo in the [XMTP](https://github.com/xmtp) or [Ephemera](https://github.com/ephemeraHQ) GitHub org is meerged you're eligible to claim this [XMTP contributor POAP](https://www.gitpoap.io/gp/1042).
 
 ## XMTP Improvement Proposals
 


### PR DESCRIPTION
Сorrected the links that should lead to the official [Ephemera](https://github.com/xmtp-labs) github account but lead to a non-existent github account, it is desirable to fix soon to prevent the possibility of scamming

<img width="433" alt="Снимок экрана 2025-03-03 в 12 15 57" src="https://github.com/user-attachments/assets/883337d3-fd59-4159-a3e2-753d37e5012a" />
<img width="1119" alt="Снимок экрана 2025-03-03 в 12 16 24" src="https://github.com/user-attachments/assets/997c5e4a-6857-4b39-a0a0-2aaded1084df" />
orrected the links that should lead to the official github account but lead to a non-existent site, it is desirable to fix soon to prevent the possibility of scamming