### PR TITLE
Fix typo

### DIFF
--- a/docs/concepts/decentralizing-xmtp.md
+++ b/docs/concepts/decentralizing-xmtp.md
@@ -5,14 +5,14 @@ sidebar_position: 4
 
 # Decentralizing XMTP
 
-Today we're announcing a new chapter for XMTP: a decentralized messaging network powered by the [Messaging Layer Security standard](https://messaginglayersecurity.rocks/) standard - the most secure and private messaging protocol available to developers.  Our entire protocol is open source, from the [node software](https://github.com/xmtp/xmtp-node-go) to the [SDKs](https://github.com/xmtp) to the [Converse app](https://github.com/ephemerahq/converse-app).
+Today we're announcing a new chapter for XMTP: a decentralized messaging network powered by the [Messaging Layer Security standard](https://messaginglayersecurity.rocks/) - the most secure and private messaging protocol available to developers.  Our entire protocol is open source, from the [node software](https://github.com/xmtp/xmtp-node-go) to the [SDKs](https://github.com/xmtp) to the [Converse app](https://github.com/ephemerahq/converse-app).
 
 Until now, the backend of the network has been centralized. All the nodes are run by [Ephemera](https://ephemerahq.com/). It’s time to change that.
 
 ## Why decentralization matters
 
 1. Devs are tired of getting rugged by platforms who can change the rules any time it suits their business interests.
-2. Devs want to be owners of the network and share in the economic value that they are creating
+2. Devs want to be owners of the network and share in the economic value that they are creating.
 3. Devs should feel confident that the platform they are building on will not live or die with a single company.
 
 ## How does the network work?

--- a/docs/concepts/decentralizing-xmtp.md
+++ b/docs/concepts/decentralizing-xmtp.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 # Decentralizing XMTP
 
-Today we're announcing a new chapter for XMTP: a decentralized messaging network powered by the [Messaging Layer Security standard](https://messaginglayersecurity.rocks/) - the most secure and private messaging protocol available to developers.  Our entire protocol is open source, from the [node software](https://github.com/xmtp/xmtp-node-go) to the [SDKs](https://github.com/xmtp) to the [Converse app](https://github.com/ephemerahq/converse-app).
+Today we're announcing a new chapter for XMTP: a decentralized messaging network powered by the [Messaging Layer Security standard](https://messaginglayersecurity.rocks/) - the most secure and private messaging protocol available to developers. Our entire protocol is open source, from the [node software](https://github.com/xmtp/xmtp-node-go) to the [SDKs](https://github.com/xmtp) to the [Converse app](https://github.com/ephemerahq/converse-app).
 
 Until now, the backend of the network has been centralized. All the nodes are run by [Ephemera](https://ephemerahq.com/). It’s time to change that.
 


### PR DESCRIPTION
### Fix typo in docs/concepts/decentralizing-xmtp.md by correcting a duplicated word, normalizing spacing from 2 spaces after a period to 1, and adding missing punctuation
Update [decentralizing-xmtp.md](https://github.com/xmtp/xmtp-dot-org/pull/837/files#diff-fb3970b8abf84b5c331b825d194714b8b1430d7753911375872b4963cb53c08e):
- Remove the duplicated word “standard” following the Messaging Layer Security link.
- Change double spaces after periods to a single space (2 → 1).
- Add a period at the end of list item 2.

#### 📍Where to Start
Start with the content edits in [decentralizing-xmtp.md](https://github.com/xmtp/xmtp-dot-org/pull/837/files#diff-fb3970b8abf84b5c331b825d194714b8b1430d7753911375872b4963cb53c08e).

----

_[Macroscope](https://app.macroscope.com) summarized 686a987._