### PR TITLE
Update identity section on home page

### DIFF
--- a/src/components/BuiltWithXmtp/index.js
+++ b/src/components/BuiltWithXmtp/index.js
@@ -457,8 +457,9 @@ const BuiltWithXmtp = () => {
               <div class="lg:max-w-lg">
                 <h2 class="text-base/7 font-semibold text-red-500">Identity</h2>
                 <p class="mt-2 text-pretty text-4xl font-semibold tracking-tight">Built for digital identities</p>
-                <p class="mt-6 text-md/8 md:text-lg/8">XMTP makes any digital identity your passport to secure, censorship-resistant messaging.<ul><li>Works with wallets, passkeys, World ID, and social IDs like Base, Farcaster, ENS.</li><li>Built to support new networks like Bluesky, Nostr, or any other identity you own.</li><li>Delivers end-to-end encrypted, quantum-safe messaging on open cryptographic rails.</li></ul>
+                <p class="mt-6 text-md/8 md:text-lg/8">XMTP makes any digital identity your passport to secure, censorship-resistant messaging.
                 </p>
+                <ul class="text-md/8 md:text-lg/8"><li>Works with wallets, passkeys, World ID, and social IDs like Base, Farcaster, ENS.</li><li>Built to support new networks like Bluesky, Nostr, or any other identity you own.</li><li>Delivers end-to-end encrypted, quantum-safe messaging on open cryptographic rails.</li></ul>
                 <p class="mt-12">
 
                 <a href="/docs/concepts/identity" class="text-md/8 md:text-lg/8 cursor-pointer items-center gap-x-1 text-white bg-gray-900 hover:text-white shadow-sm hover:bg-red-600 transition-all font-semibold rounded-md text-base text-center inline-flex items-center me-2 px-5 py-3.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400 w-full md:w-auto justify-center md:justify-normal hover:no-underline">


### PR DESCRIPTION
### Update the home page Identity section in the `BuiltWithXmtp` component to replace the body copy with a shorter statement and add a 3-item unordered list
In [index.js](https://github.com/xmtp/xmtp-dot-org/pull/840/files#diff-08a99f074480fc8edb4d593d7f1df277cb8f1237303355acada1c0cc60f48f6f), the JSX for the `BuiltWithXmtp` Identity section is updated:

- Replace the descriptive paragraph with a shorter sentence.
- Insert an unordered list with three bullet points covering identity support and encryption claims.
- Modify the subheading paragraph text.

#### 📍Where to Start
Start with the Identity subsection of the `BuiltWithXmtp` component in [index.js](https://github.com/xmtp/xmtp-dot-org/pull/840/files#diff-08a99f074480fc8edb4d593d7f1df277cb8f1237303355acada1c0cc60f48f6f).

----

_[Macroscope](https://app.macroscope.com) summarized 5a31e79._