### PR TITLE
lil fixes

### DIFF
--- a/vision/concepts/security.mdx
+++ b/vision/concepts/security.mdx
@@ -27,8 +27,8 @@ Your messages get the same robust protection that users expect from Signal and W
 - **Perfect forward secrecy**: Past messages stay secure even if current keys are compromised
 - **Post-compromise security**: Future messages remain protected even after a security breach
 - **End-to-end protection**: Messages stay private between sender and recipient—even network nodes can't read them
-- **Scalable group security**: Efficient rekeying and membership updates for groups ranging from small chats to thousands of participants.
-- **Tamper-proof:** Every message is cryptographically signed, ensuring messages can’t be forged or altered in transit.
+- **Scalable group security**: Efficient rekeying and membership updates for groups ranging from small chats to thousands of participants
+- **Tamper-proof:** Every message is cryptographically signed, ensuring messages can't be forged or altered in transit
 
 ### Message content and metadata privacy by default
 
@@ -42,7 +42,7 @@ Read more about [XMTP and the Future of Privacy in a Quantum World](https://comm
 
 ### Fully audited and open source
 
-XMTP's MLS implementation is fully open source, and a [security assessment](https://www.nccgroup.com/us/research-blog/public-report-xmtp-mls-implementation-review/) of the [LibXMTP](https://github.com/xmtp/libxmtp) core library and its use of MLS was completed by NCC Group in December 2024. Built on IETF standards, the protocol's efficiency aims to keep network costs low while delivering enterprise-grade protection at scale. 
+XMTP's MLS implementation is fully open source, and a [security assessment](https://www.nccgroup.com/us/research-blog/public-report-xmtp-mls-implementation-review/) of the [LibXMTP](https://github.com/xmtp/libxmtp) core library and its use of MLS was completed by NCC Group in December 2024. Built on IETF standards, the protocol's efficiency aims to keep network costs low while delivering enterprise-grade protection at scale. 
 
 ### Secure messaging that just works
 
@@ -53,7 +53,7 @@ Whether you're building chat apps or agents, XMTP's security architecture delive
 :::info Learn more
 
 - XMTP security overview docs: [Messaging security properties with XMTP](https://docs.xmtp.org/protocol/security)
-- See XMTP's [implementation of MLS in the LibXMTP core library](https://github.com/xmtp/libxmtp/tree/main/xmtp_mls).
+- See XMTP's [implementation of MLS in the LibXMTP core library](https://github.com/xmtp/libxmtp/tree/main/xmtp_mls)
 - [Security FAQ](https://docs.xmtp.org/protocol/security#faq-about-messaging-security)
 
 :::


### PR DESCRIPTION
### Standardize punctuation and spacing in the vision/concepts/security.mdx documentation for lil fixes
Update the [security.mdx](https://github.com/xmtp/xmtp-dot-org/pull/849/files#diff-c7565c3e70896ba4347217d35bc7ed2695d25838d61eef9d175a4692d2bbae14) documentation to normalize punctuation and spacing. Changes include removing trailing periods from list items, replacing a curly apostrophe in `can’t` with a straight apostrophe in `can't`, converting a non-breaking space before `the` to a normal space, and removing a trailing period after a link in the Learn more list.

#### 📍Where to Start
Start by reviewing the content edits in [vision/concepts/security.mdx](https://github.com/xmtp/xmtp-dot-org/pull/849/files#diff-c7565c3e70896ba4347217d35bc7ed2695d25838d61eef9d175a4692d2bbae14).

----

_[Macroscope](https://app.macroscope.com) summarized 1d01236._