### PR TITLE
Fix footer privacy link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -215,7 +215,7 @@ const config = {
             items: [
               {
                 label: "Privacy policy",
-                to: "privacy",
+                to: "/privacy",
               },
               {
                 label: "Terms of service",


### PR DESCRIPTION
Updates the footer's Privacy policy link from `privacy` to `/privacy`.

The Terms link next to it already uses an absolute site path. Keeping Privacy absolute too avoids resolving it relative to nested routes when the footer is rendered across docs and blog pages.

Checked with `npm ci --ignore-scripts` and a Docusaurus production build via PowerShell (`$env:NODE_OPTIONS='--max-old-space-size=4096'; npx docusaurus build`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix footer privacy policy link to use an absolute path
> Changes the 'Privacy policy' link in the site footer from the relative path `privacy` to the absolute path `/privacy` in [docusaurus.config.js](https://github.com/xmtp/xmtp-dot-org/pull/860/files#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2a). This ensures the link navigates correctly regardless of the current page's URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1877492.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->